### PR TITLE
Refactor DB context handling in SQL commands

### DIFF
--- a/Sandbox/Repositories/SandboxRepository.cs
+++ b/Sandbox/Repositories/SandboxRepository.cs
@@ -9,7 +9,7 @@ using CaeriusNet.Sandbox.Repositories.Interfaces;
 
 namespace CaeriusNet.Sandbox.Repositories;
 
-public sealed record SandboxRepository(ICaeriusDbConnectionFactory Connection) : ISandboxRepository
+public sealed record SandboxRepository(ICaeriusDbContext Context) : ISandboxRepository
 {
     public string GetSandboxMessage()
     {
@@ -19,7 +19,7 @@ public sealed record SandboxRepository(ICaeriusDbConnectionFactory Connection) :
     public async Task<IEnumerable<UsersDto>> GetUsers()
     {
         var spParameters = new StoredProcedureParametersBuilder("dbo.sp_get_users", 100);
-        IEnumerable<UsersDto> users = await Connection.QueryAsync<UsersDto>(spParameters);
+        IEnumerable<UsersDto> users = await Context.QueryAsync<UsersDto>(spParameters);
         return users;
     }
 
@@ -28,7 +28,7 @@ public sealed record SandboxRepository(ICaeriusDbConnectionFactory Connection) :
         var spParameters = new StoredProcedureParametersBuilder("dbo.sp_create_users_with_tvp")
             .AddTvpParameter("MyTvpUsers", "dbo.tvp_newUsers", users);
 
-        var dbResults = await Connection.ExecuteAsync(spParameters);
+        var dbResults = await Context.ExecuteAsync(spParameters);
 
         Console.WriteLine($"Rows affected: {dbResults}");
     }
@@ -38,12 +38,12 @@ public sealed record SandboxRepository(ICaeriusDbConnectionFactory Connection) :
         var spParameters = new StoredProcedureParametersBuilder("dbo.sp_update_user_age")
             .AddTvpParameter("MyTvpUserAge", "dbo.tvp_userAge", users);
 
-        return Connection.ExecuteScalarAsync(spParameters);
+        return Context.ExecuteScalarAsync(spParameters);
     }
 
     public Task<ReadOnlyCollection<UsersTestingDto>> GetUsersTesting()
     {
         var spParameters = new StoredProcedureParametersBuilder("dbo.sp_get_all_users", 38000);
-        return Connection.QueryAsync<UsersTestingDto>(spParameters);
+        return Context.QueryAsync<UsersTestingDto>(spParameters);
     }
 }

--- a/Src/Builders/StoredProcedureParametersBuilder.cs
+++ b/Src/Builders/StoredProcedureParametersBuilder.cs
@@ -21,7 +21,8 @@ public sealed record StoredProcedureParametersBuilder(string ProcedureName, int 
     /// <returns>The <see cref="StoredProcedureParametersBuilder" /> instance for chaining.</returns>
     public StoredProcedureParametersBuilder AddParameter(string parameter, object value, SqlDbType dbType)
     {
-        Parameters.Add(new SqlParameter(parameter, dbType) { Value = value });
+        var itemParameter = new SqlParameter(parameter, dbType) { Value = value };
+        Parameters.Add(itemParameter);
         return this;
     }
 

--- a/Src/Commands/Reads/MultiIEnumerableReadSqlAsyncCommands.cs
+++ b/Src/Commands/Reads/MultiIEnumerableReadSqlAsyncCommands.cs
@@ -15,24 +15,22 @@ public static class MultiIEnumerableReadSqlAsyncCommands
     /// </summary>
     /// <typeparam name="TResultSet1">The type of the first result set, must implement <see cref="ISpMapper{T}" />.</typeparam>
     /// <typeparam name="TResultSet2">The type of the second result set, must implement <see cref="ISpMapper{T}" />.</typeparam>
-    /// <param name="connectionFactory">The database connection factory.</param>
+    /// <param name="context">The database connection factory.</param>
     /// <param name="spParameters">The stored procedure parameters builder.</param>
-    /// <param name="map1">A function to map the first result set to <typeparamref name="TResultSet1" />.</param>
-    /// <param name="map2">A function to map the second result set to <typeparamref name="TResultSet2" />.</param>
+    /// <param name="resultSet1">A function to map the first result set to <typeparamref name="TResultSet1" />.</param>
+    /// <param name="resultSet2">A function to map the second result set to <typeparamref name="TResultSet2" />.</param>
     /// <returns>The task result is a tuple where each item is an IEnumerable of the mapped result sets.</returns>
-    public static async Task<(IEnumerable<TResultSet1>, IEnumerable<TResultSet2>)> QueryMultipleIEnumerableAsync<
-        TResultSet1, TResultSet2>(
-        this ICaeriusDbConnectionFactory connectionFactory,
-        StoredProcedureParametersBuilder spParameters,
-        Func<SqlDataReader, TResultSet1> map1,
-        Func<SqlDataReader, TResultSet2> map2)
+    public static async Task<(IEnumerable<TResultSet1>, IEnumerable<TResultSet2>)>
+        QueryMultipleIEnumerableAsync<TResultSet1, TResultSet2>(
+            this ICaeriusDbContext context, StoredProcedureParametersBuilder spParameters,
+            Func<SqlDataReader, TResultSet1> resultSet1, Func<SqlDataReader, TResultSet2> resultSet2)
         where TResultSet1 : class
         where TResultSet2 : class
     {
-        var results = await connectionFactory.ReadMultipleIEnumerableResultSetsAsync(spParameters, map1, map2);
+        var results = await context
+            .ReadMultipleIEnumerableResultSetsAsync(spParameters, resultSet1, resultSet2);
 
-        return (results[0].Cast<TResultSet1>(),
-            results[1].Cast<TResultSet2>());
+        return (results[0].Cast<TResultSet1>(), results[1].Cast<TResultSet2>());
     }
 
     /// <summary>
@@ -41,30 +39,27 @@ public static class MultiIEnumerableReadSqlAsyncCommands
     /// <typeparam name="TResultSet1">The type of the first result set, must implement <see cref="ISpMapper{T}" />.</typeparam>
     /// <typeparam name="TResultSet2">The type of the second result set, must implement <see cref="ISpMapper{T}" />.</typeparam>
     /// <typeparam name="TResultSet3">The type of the third result set, must implement <see cref="ISpMapper{T}" />.</typeparam>
-    /// <param name="connectionFactory">The database connection factory.</param>
+    /// <param name="context">The database connection factory.</param>
     /// <param name="spParameters">The stored procedure parameters builder.</param>
-    /// <param name="map1">A function to map the first result set to <typeparamref name="TResultSet1" />.</param>
-    /// <param name="map2">A function to map the second result set to <typeparamref name="TResultSet2" />.</param>
-    /// <param name="map3">A function to map the third result set to <typeparamref name="TResultSet3" />.</param>
+    /// <param name="resultSet1">A function to map the first result set to <typeparamref name="TResultSet1" />.</param>
+    /// <param name="resultSet2">A function to map the second result set to <typeparamref name="TResultSet2" />.</param>
+    /// <param name="resultSet3">A function to map the third result set to <typeparamref name="TResultSet3" />.</param>
     /// <returns>The task result is a tuple where each item is an IEnumerable of the mapped result sets.</returns>
     public static async Task<(IEnumerable<TResultSet1>, IEnumerable<TResultSet2>, IEnumerable<TResultSet3>)>
-        QueryMultipleIEnumerableAsync<TResultSet1, TResultSet2,
-            TResultSet3>(
-            this ICaeriusDbConnectionFactory connectionFactory,
+        QueryMultipleIEnumerableAsync<TResultSet1, TResultSet2, TResultSet3>(
+            this ICaeriusDbContext context,
             StoredProcedureParametersBuilder spParameters,
-            Func<SqlDataReader, TResultSet1> map1,
-            Func<SqlDataReader, TResultSet2> map2,
-            Func<SqlDataReader, TResultSet3> map3)
+            Func<SqlDataReader, TResultSet1> resultSet1,
+            Func<SqlDataReader, TResultSet2> resultSet2,
+            Func<SqlDataReader, TResultSet3> resultSet3)
         where TResultSet1 : class, ISpMapper<TResultSet1>
         where TResultSet2 : class, ISpMapper<TResultSet2>
         where TResultSet3 : class, ISpMapper<TResultSet3>
     {
-        var results =
-            await connectionFactory.ReadMultipleIEnumerableResultSetsAsync(spParameters, map1, map2, map3);
+        var results = await context
+            .ReadMultipleIEnumerableResultSetsAsync(spParameters, resultSet1, resultSet2, resultSet3);
 
-        return (results[0].Cast<TResultSet1>(),
-            results[1].Cast<TResultSet2>(),
-            results[2].Cast<TResultSet3>());
+        return (results[0].Cast<TResultSet1>(), results[1].Cast<TResultSet2>(), results[2].Cast<TResultSet3>());
     }
 
     /// <summary>
@@ -74,33 +69,31 @@ public static class MultiIEnumerableReadSqlAsyncCommands
     /// <typeparam name="TResultSet2">The type of the second result set, must implement <see cref="ISpMapper{T}" />.</typeparam>
     /// <typeparam name="TResultSet3">The type of the third result set, must implement <see cref="ISpMapper{T}" />.</typeparam>
     /// <typeparam name="TResultSet4">The type of the fourth result set, must implement <see cref="ISpMapper{T}" />.</typeparam>
-    /// <param name="connectionFactory">The database connection factory.</param>
+    /// <param name="context">The database connection factory.</param>
     /// <param name="spParameters">The stored procedure parameters builder.</param>
-    /// <param name="map1">A function to map the first result set to <typeparamref name="TResultSet1" />.</param>
-    /// <param name="map2">A function to map the second result set to <typeparamref name="TResultSet2" />.</param>
-    /// <param name="map3">A function to map the third result set to <typeparamref name="TResultSet3" />.</param>
-    /// <param name="map4">A function to map the fourth result set to <typeparamref name="TResultSet4" />.</param>
+    /// <param name="resultSet1">A function to map the first result set to <typeparamref name="TResultSet1" />.</param>
+    /// <param name="resultSet2">A function to map the second result set to <typeparamref name="TResultSet2" />.</param>
+    /// <param name="resultSet3">A function to map the third result set to <typeparamref name="TResultSet3" />.</param>
+    /// <param name="resultSet4">A function to map the fourth result set to <typeparamref name="TResultSet4" />.</param>
     /// <returns>The task result is a tuple where each item is an IEnumerable of the mapped result sets.</returns>
     public static async Task<(IEnumerable<TResultSet1>, IEnumerable<TResultSet2>, IEnumerable<TResultSet3>,
             IEnumerable<TResultSet4>)>
         QueryMultipleIEnumerableAsync<TResultSet1, TResultSet2, TResultSet3, TResultSet4>(
-            this ICaeriusDbConnectionFactory connectionFactory,
+            this ICaeriusDbContext context,
             StoredProcedureParametersBuilder spParameters,
-            Func<SqlDataReader, TResultSet1> map1,
-            Func<SqlDataReader, TResultSet2> map2,
-            Func<SqlDataReader, TResultSet3> map3,
-            Func<SqlDataReader, TResultSet4> map4)
+            Func<SqlDataReader, TResultSet1> resultSet1,
+            Func<SqlDataReader, TResultSet2> resultSet2,
+            Func<SqlDataReader, TResultSet3> resultSet3,
+            Func<SqlDataReader, TResultSet4> resultSet4)
         where TResultSet1 : class, ISpMapper<TResultSet1>
         where TResultSet2 : class, ISpMapper<TResultSet2>
         where TResultSet3 : class, ISpMapper<TResultSet3>
         where TResultSet4 : class, ISpMapper<TResultSet4>
     {
-        var results =
-            await connectionFactory.ReadMultipleIEnumerableResultSetsAsync(spParameters, map1, map2, map3, map4);
+        var results = await context
+            .ReadMultipleIEnumerableResultSetsAsync(spParameters, resultSet1, resultSet2, resultSet3, resultSet4);
 
-        return (results[0].Cast<TResultSet1>(),
-            results[1].Cast<TResultSet2>(),
-            results[2].Cast<TResultSet3>(),
+        return (results[0].Cast<TResultSet1>(), results[1].Cast<TResultSet2>(), results[2].Cast<TResultSet3>(),
             results[3].Cast<TResultSet4>());
     }
 
@@ -112,24 +105,24 @@ public static class MultiIEnumerableReadSqlAsyncCommands
     /// <typeparam name="TResultSet3">The type of the third result set, must implement <see cref="ISpMapper{T}" />.</typeparam>
     /// <typeparam name="TResultSet4">The type of the fourth result set, must implement <see cref="ISpMapper{T}" />.</typeparam>
     /// <typeparam name="TResultSet5">The type of the fifth result set, must implement <see cref="ISpMapper{T}" />.</typeparam>
-    /// <param name="connectionFactory">The database connection factory.</param>
+    /// <param name="context">The database connection factory.</param>
     /// <param name="spParameters">The stored procedure parameters builder.</param>
-    /// <param name="map1">A function to map the first result set to <typeparamref name="TResultSet1" />.</param>
-    /// <param name="map2">A function to map the second result set to <typeparamref name="TResultSet2" />.</param>
-    /// <param name="map3">A function to map the third result set to <typeparamref name="TResultSet3" />.</param>
-    /// <param name="map4">A function to map the fourth result set to <typeparamref name="TResultSet4" />.</param>
-    /// <param name="map5">A function to map the fifth result set to <typeparamref name="TResultSet5" />.</param>
+    /// <param name="resultSet1">A function to map the first result set to <typeparamref name="TResultSet1" />.</param>
+    /// <param name="resultSet2">A function to map the second result set to <typeparamref name="TResultSet2" />.</param>
+    /// <param name="resultSet3">A function to map the third result set to <typeparamref name="TResultSet3" />.</param>
+    /// <param name="resultSet4">A function to map the fourth result set to <typeparamref name="TResultSet4" />.</param>
+    /// <param name="resultSet5">A function to map the fifth result set to <typeparamref name="TResultSet5" />.</param>
     /// <returns>The task result is a tuple where each item is an IEnumerable of the mapped result sets.</returns>
     public static async Task<(IEnumerable<TResultSet1>, IEnumerable<TResultSet2>, IEnumerable<TResultSet3>,
             IEnumerable<TResultSet4>, IEnumerable<TResultSet5>)>
         QueryMultipleIEnumerableAsync<TResultSet1, TResultSet2, TResultSet3, TResultSet4, TResultSet5>(
-            this ICaeriusDbConnectionFactory connectionFactory,
+            this ICaeriusDbContext context,
             StoredProcedureParametersBuilder spParameters,
-            Func<SqlDataReader, TResultSet1> map1,
-            Func<SqlDataReader, TResultSet2> map2,
-            Func<SqlDataReader, TResultSet3> map3,
-            Func<SqlDataReader, TResultSet4> map4,
-            Func<SqlDataReader, TResultSet5> map5)
+            Func<SqlDataReader, TResultSet1> resultSet1,
+            Func<SqlDataReader, TResultSet2> resultSet2,
+            Func<SqlDataReader, TResultSet3> resultSet3,
+            Func<SqlDataReader, TResultSet4> resultSet4,
+            Func<SqlDataReader, TResultSet5> resultSet5)
         where TResultSet1 : class, ISpMapper<TResultSet1>
         where TResultSet2 : class, ISpMapper<TResultSet2>
         where TResultSet3 : class, ISpMapper<TResultSet3>
@@ -137,19 +130,17 @@ public static class MultiIEnumerableReadSqlAsyncCommands
         where TResultSet5 : class, ISpMapper<TResultSet5>
     {
         var results =
-            await connectionFactory.ReadMultipleIEnumerableResultSetsAsync(spParameters, map1, map2, map3, map4, map5);
+            await context.ReadMultipleIEnumerableResultSetsAsync(spParameters, resultSet1, resultSet2, resultSet3,
+                resultSet4, resultSet5);
 
-        return (results[0].Cast<TResultSet1>(),
-            results[1].Cast<TResultSet2>(),
-            results[2].Cast<TResultSet3>(),
-            results[3].Cast<TResultSet4>(),
-            results[4].Cast<TResultSet5>());
+        return (results[0].Cast<TResultSet1>(), results[1].Cast<TResultSet2>(), results[2].Cast<TResultSet3>(),
+            results[3].Cast<TResultSet4>(), results[4].Cast<TResultSet5>());
     }
 
     /// <summary>
     ///     Asynchronously queries the database for multiple result sets and maps them to a list of IEnumerable collections.
     /// </summary>
-    /// <param name="connectionFactory">The database connection factory to create a connection.</param>
+    /// <param name="context">The database connection factory to create a connection.</param>
     /// <param name="spParameters">The stored procedure parameters builder to configure the command.</param>
     /// <param name="mappers">An array of functions to map each result set to a specific object type.</param>
     /// <returns>
@@ -158,14 +149,13 @@ public static class MultiIEnumerableReadSqlAsyncCommands
     /// </returns>
     /// <exception cref="ArgumentException">Thrown when no mapper functions are provided.</exception>
     private static async Task<List<IEnumerable<object>>> ReadMultipleIEnumerableResultSetsAsync(
-        this ICaeriusDbConnectionFactory connectionFactory,
-        StoredProcedureParametersBuilder spParameters,
+        this ICaeriusDbContext context, StoredProcedureParametersBuilder spParameters,
         params Func<SqlDataReader, object>[] mappers)
     {
         if (mappers.Length == 0)
             throw new ArgumentException("At least one mapper function must be provided.", nameof(mappers));
 
-        using var connection = connectionFactory.DbConnection();
+        using var connection = context.DbConnection();
         await using var command = await SqlCommandUtility.ExecuteSqlCommand(spParameters, connection);
         await using var reader = await command.ExecuteReaderAsync();
 

--- a/Src/Commands/Reads/MultiImmutableArrayReadSqlAsyncCommands.cs
+++ b/Src/Commands/Reads/MultiImmutableArrayReadSqlAsyncCommands.cs
@@ -15,14 +15,14 @@ public static class MultiImmutableArrayReadSqlAsyncCommands
     /// </summary>
     /// <typeparam name="TResultSet1">The type of objects in the first result set, must implement <see cref="ISpMapper{T}" />.</typeparam>
     /// <typeparam name="TResultSet2">The type of the second result set, must implement <see cref="ISpMapper{T}" />.</typeparam>
-    /// <param name="connectionFactory">The factory to create a database connection.</param>
+    /// <param name="context">The factory to create a database connection.</param>
     /// <param name="spParameters">The parameters for the stored procedure.</param>
     /// <param name="map1">A function to map the first result set to <typeparamref name="TResultSet1" />.</param>
     /// <param name="map2">A function to map the second result set to <typeparamref name="TResultSet2" />.</param>
     /// <returns>The task result is a tuple where each item is an ImmutableArray of the mapped result sets.</returns>
     public static async Task<(ImmutableArray<TResultSet1>, ImmutableArray<TResultSet2>)>
         QueryMultipleImmutableArrayAsync<TResultSet1, TResultSet2>(
-            this ICaeriusDbConnectionFactory connectionFactory,
+            this ICaeriusDbContext context,
             StoredProcedureParametersBuilder spParameters,
             Func<SqlDataReader, TResultSet1> map1,
             Func<SqlDataReader, TResultSet2> map2)
@@ -30,7 +30,7 @@ public static class MultiImmutableArrayReadSqlAsyncCommands
         where TResultSet2 : class, ISpMapper<TResultSet2>
     {
         var results =
-            await connectionFactory.ReadMultipleImmutableArrayResultSetsAsync(spParameters, map1, map2);
+            await context.ReadMultipleImmutableArrayResultSetsAsync(spParameters, map1, map2);
 
         return ([..results[0].Cast<TResultSet1>()],
             [..results[1].Cast<TResultSet2>()]);
@@ -42,7 +42,7 @@ public static class MultiImmutableArrayReadSqlAsyncCommands
     /// <typeparam name="TResultSet1">The type of the first result set, must implement <see cref="ISpMapper{T}" />.</typeparam>
     /// <typeparam name="TResultSet2">The type of the second result set, must implement <see cref="ISpMapper{T}" />.</typeparam>
     /// <typeparam name="TResultSet3">The type of the third result set, must implement <see cref="ISpMapper{T}" />.</typeparam>
-    /// <param name="connectionFactory">The factory to create a database connection.</param>
+    /// <param name="context">The factory to create a database connection.</param>
     /// <param name="spParameters">The parameters for the stored procedure.</param>
     /// <param name="map1">A function to map the first result set to <typeparamref name="TResultSet1" />.</param>
     /// <param name="map2">A function to map the second result set to <typeparamref name="TResultSet2" />.</param>
@@ -50,7 +50,7 @@ public static class MultiImmutableArrayReadSqlAsyncCommands
     /// <returns>The task result is a tuple where each item is an ImmutableArray of the mapped result sets.</returns>
     public static async Task<(ImmutableArray<TResultSet1>, ImmutableArray<TResultSet2>, ImmutableArray<TResultSet3>)>
         QueryMultipleImmutableArrayAsync<TResultSet1, TResultSet2, TResultSet3>(
-            this ICaeriusDbConnectionFactory connectionFactory,
+            this ICaeriusDbContext context,
             StoredProcedureParametersBuilder spParameters,
             Func<SqlDataReader, TResultSet1> map1,
             Func<SqlDataReader, TResultSet2> map2,
@@ -60,7 +60,7 @@ public static class MultiImmutableArrayReadSqlAsyncCommands
         where TResultSet3 : class, ISpMapper<TResultSet3>
     {
         var results =
-            await connectionFactory.ReadMultipleImmutableArrayResultSetsAsync(spParameters, map1, map2, map3);
+            await context.ReadMultipleImmutableArrayResultSetsAsync(spParameters, map1, map2, map3);
 
         return ([..results[0].Cast<TResultSet1>()],
             [..results[1].Cast<TResultSet2>()],
@@ -74,18 +74,19 @@ public static class MultiImmutableArrayReadSqlAsyncCommands
     /// <typeparam name="TResultSet2">The type of objects in the second result set.</typeparam>
     /// <typeparam name="TResultSet3">The type of objects in the third result set.</typeparam>
     /// <typeparam name="TResultSet4">The type of objects in the fourth result set.</typeparam>
-    /// <param name="connectionFactory">The factory to create a database connection.</param>
+    /// <param name="context">The factory to create a database connection.</param>
     /// <param name="spParameters">The parameters for the stored procedure.</param>
     /// <param name="map1">A function to map the first result set to <typeparamref name="TResultSet1" />.</param>
     /// <param name="map2">A function to map the second result set to <typeparamref name="TResultSet2" />.</param>
     /// <param name="map3">A function to map the third result set to <typeparamref name="TResultSet3" />.</param>
     /// <param name="map4">A function to map the fourth result set to <typeparamref name="TResultSet4" />.</param>
     /// <returns>The task result is a tuple where each item is an ImmutableArray of the mapped result sets.</returns>
-    public static async
-        Task<(ImmutableArray<TResultSet1>, ImmutableArray<TResultSet2>, ImmutableArray<TResultSet3>,
+    public static async Task<(ImmutableArray<TResultSet1>,
+            ImmutableArray<TResultSet2>,
+            ImmutableArray<TResultSet3>,
             ImmutableArray<TResultSet4>)>
         QueryMultipleImmutableArrayAsync<TResultSet1, TResultSet2, TResultSet3, TResultSet4>(
-            this ICaeriusDbConnectionFactory connectionFactory,
+            this ICaeriusDbContext context,
             StoredProcedureParametersBuilder spParameters,
             Func<SqlDataReader, TResultSet1> map1,
             Func<SqlDataReader, TResultSet2> map2,
@@ -97,7 +98,7 @@ public static class MultiImmutableArrayReadSqlAsyncCommands
         where TResultSet4 : class, ISpMapper<TResultSet4>
     {
         var results =
-            await connectionFactory.ReadMultipleImmutableArrayResultSetsAsync(spParameters, map1, map2, map3, map4);
+            await context.ReadMultipleImmutableArrayResultSetsAsync(spParameters, map1, map2, map3, map4);
 
         return ([..results[0].Cast<TResultSet1>()],
             [..results[1].Cast<TResultSet2>()],
@@ -113,7 +114,7 @@ public static class MultiImmutableArrayReadSqlAsyncCommands
     /// <typeparam name="TResultSet3">The type of objects in the third result set.</typeparam>
     /// <typeparam name="TResultSet4">The type of objects in the fourth result set.</typeparam>
     /// <typeparam name="TResultSet5">The type of objects in the fifth result set.</typeparam>
-    /// <param name="connectionFactory">The factory to create a database connection.</param>
+    /// <param name="context">The factory to create a database connection.</param>
     /// <param name="spParameters">The parameters for the stored procedure.</param>
     /// <param name="map1">A function to map the first result set to <typeparamref name="TResultSet1" />.</param>
     /// <param name="map2">A function to map the second result set to <typeparamref name="TResultSet2" />.</param>
@@ -127,7 +128,7 @@ public static class MultiImmutableArrayReadSqlAsyncCommands
             ImmutableArray<TResultSet4>,
             ImmutableArray<TResultSet5>)> QueryMultipleImmutableArrayAsync<TResultSet1, TResultSet2, TResultSet3,
             TResultSet4, TResultSet5>(
-            this ICaeriusDbConnectionFactory connectionFactory,
+            this ICaeriusDbContext context,
             StoredProcedureParametersBuilder spParameters,
             Func<SqlDataReader, TResultSet1> map1,
             Func<SqlDataReader, TResultSet2> map2,
@@ -141,7 +142,7 @@ public static class MultiImmutableArrayReadSqlAsyncCommands
         where TResultSet5 : class, ISpMapper<TResultSet5>
     {
         var results =
-            await connectionFactory.ReadMultipleImmutableArrayResultSetsAsync(spParameters, map1, map2, map3, map4,
+            await context.ReadMultipleImmutableArrayResultSetsAsync(spParameters, map1, map2, map3, map4,
                 map5);
 
         return ([..results[0].Cast<TResultSet1>()],
@@ -154,7 +155,7 @@ public static class MultiImmutableArrayReadSqlAsyncCommands
     /// <summary>
     ///     Asynchronously queries the database for multiple result sets and maps them to a list of ImmutableArray collections.
     /// </summary>
-    /// <param name="connectionFactory">The database connection factory to create a connection.</param>
+    /// <param name="context">The database connection factory to create a connection.</param>
     /// <param name="spParameters">The stored procedure parameters builder to configure the command.</param>
     /// <param name="mappers">An array of functions to map each result set to a specific object type.</param>
     /// <returns>
@@ -167,14 +168,14 @@ public static class MultiImmutableArrayReadSqlAsyncCommands
     ///     converting each result set into a strongly-typed ImmutableArray based on the provided mapper functions.
     /// </remarks>
     private static async Task<List<ImmutableArray<object>>> ReadMultipleImmutableArrayResultSetsAsync(
-        this ICaeriusDbConnectionFactory connectionFactory,
+        this ICaeriusDbContext context,
         StoredProcedureParametersBuilder spParameters,
         params Func<SqlDataReader, object>[] mappers)
     {
         if (mappers.Length == 0)
             throw new ArgumentException("At least one mapper function must be provided.", nameof(mappers));
 
-        using var connection = connectionFactory.DbConnection();
+        using var connection = context.DbConnection();
         await using var command = await SqlCommandUtility.ExecuteSqlCommand(spParameters, connection);
         await using var reader = await command.ExecuteReaderAsync();
 

--- a/Src/Commands/Reads/MultiReadOnlyCollectionReadSqlAsyncCommands.cs
+++ b/Src/Commands/Reads/MultiReadOnlyCollectionReadSqlAsyncCommands.cs
@@ -16,22 +16,22 @@ public static class MultiReadOnlyCollectionReadSqlAsyncCommands
     /// </summary>
     /// <typeparam name="TResultSet1">The type of objects in the first result set, must implement <see cref="ISpMapper{T}" />.</typeparam>
     /// <typeparam name="TResultSet2">The type of objects in the second result set, must implement <see cref="ISpMapper{T}" />.</typeparam>
-    /// <param name="connectionFactory">The database connection factory used to create a new database connection.</param>
+    /// <param name="context">The database connection factory used to create a new database connection.</param>
     /// <param name="spParameters">The stored procedure parameters builder used to configure the command.</param>
-    /// <param name="map1">A function to map the first result set to <typeparamref name="TResultSet1" />.</param>
-    /// <param name="map2">A function to map the second result set to <typeparamref name="TResultSet2" />.</param>
+    /// <param name="resultSet1">A function to map the first result set to <typeparamref name="TResultSet1" />.</param>
+    /// <param name="resultSet2">A function to map the second result set to <typeparamref name="TResultSet2" />.</param>
     /// <returns>The task result is a tuple where each item is an IReadOnlyCollection of the result set objects.</returns>
     public static async Task<(ReadOnlyCollection<TResultSet1>, ReadOnlyCollection<TResultSet2>)>
         QueryMultipleReadOnlyCollectionAsync<TResultSet1, TResultSet2>(
-            this ICaeriusDbConnectionFactory connectionFactory,
+            this ICaeriusDbContext context,
             StoredProcedureParametersBuilder spParameters,
-            Func<SqlDataReader, TResultSet1> map1,
-            Func<SqlDataReader, TResultSet2> map2)
+            Func<SqlDataReader, TResultSet1> resultSet1,
+            Func<SqlDataReader, TResultSet2> resultSet2)
         where TResultSet1 : class, ISpMapper<TResultSet1>
         where TResultSet2 : class, ISpMapper<TResultSet2>
     {
         var results =
-            await connectionFactory.ReadMultipleIReadOnlyCollectionResultSetsAsync(spParameters, map1, map2);
+            await context.ReadMultipleIReadOnlyCollectionResultSetsAsync(spParameters, resultSet1, resultSet2);
 
         return (new ReadOnlyCollection<TResultSet1>(results[0].Cast<TResultSet1>().ToList()),
             new ReadOnlyCollection<TResultSet2>(results[1].Cast<TResultSet2>().ToList()));
@@ -40,17 +40,17 @@ public static class MultiReadOnlyCollectionReadSqlAsyncCommands
     public static async Task<(ReadOnlyCollection<TResultSet1>, ReadOnlyCollection<TResultSet2>,
             ReadOnlyCollection<TResultSet3>)>
         QueryMultipleReadOnlyCollectionAsync<TResultSet1, TResultSet2, TResultSet3>(
-            this ICaeriusDbConnectionFactory connectionFactory,
+            this ICaeriusDbContext context,
             StoredProcedureParametersBuilder spParameters,
-            Func<SqlDataReader, TResultSet1> map1,
-            Func<SqlDataReader, TResultSet2> map2,
-            Func<SqlDataReader, TResultSet3> map3)
+            Func<SqlDataReader, TResultSet1> resultSet1,
+            Func<SqlDataReader, TResultSet2> resultSet2,
+            Func<SqlDataReader, TResultSet3> resultSet3)
         where TResultSet1 : class, ISpMapper<TResultSet1>
         where TResultSet2 : class, ISpMapper<TResultSet2>
         where TResultSet3 : class, ISpMapper<TResultSet3>
     {
-        var results =
-            await connectionFactory.ReadMultipleIReadOnlyCollectionResultSetsAsync(spParameters, map1, map2, map3);
+        var results = await context
+            .ReadMultipleIReadOnlyCollectionResultSetsAsync(spParameters, resultSet1, resultSet2, resultSet3);
 
         return (new ReadOnlyCollection<TResultSet1>(results[0].Cast<TResultSet1>().ToList()),
             new ReadOnlyCollection<TResultSet2>(results[1].Cast<TResultSet2>().ToList()),
@@ -60,20 +60,20 @@ public static class MultiReadOnlyCollectionReadSqlAsyncCommands
     public static async Task<(ReadOnlyCollection<TResultSet1>, ReadOnlyCollection<TResultSet2>,
             ReadOnlyCollection<TResultSet3>, ReadOnlyCollection<TResultSet4>)>
         QueryMultipleReadOnlyCollectionAsync<TResultSet1, TResultSet2, TResultSet3, TResultSet4>(
-            this ICaeriusDbConnectionFactory connectionFactory,
+            this ICaeriusDbContext context,
             StoredProcedureParametersBuilder spParameters,
-            Func<SqlDataReader, TResultSet1> map1,
-            Func<SqlDataReader, TResultSet2> map2,
-            Func<SqlDataReader, TResultSet3> map3,
-            Func<SqlDataReader, TResultSet4> map4)
+            Func<SqlDataReader, TResultSet1> resultSet1,
+            Func<SqlDataReader, TResultSet2> resultSet2,
+            Func<SqlDataReader, TResultSet3> resultSet3,
+            Func<SqlDataReader, TResultSet4> resultSet4)
         where TResultSet1 : class, ISpMapper<TResultSet1>
         where TResultSet2 : class, ISpMapper<TResultSet2>
         where TResultSet3 : class, ISpMapper<TResultSet3>
         where TResultSet4 : class, ISpMapper<TResultSet4>
     {
-        var results =
-            await connectionFactory.ReadMultipleIReadOnlyCollectionResultSetsAsync(spParameters, map1, map2, map3,
-                map4);
+        var results = await context
+            .ReadMultipleIReadOnlyCollectionResultSetsAsync(spParameters, resultSet1, resultSet2, resultSet3,
+                resultSet4);
 
         return (new ReadOnlyCollection<TResultSet1>(results[0].Cast<TResultSet1>().ToList()),
             new ReadOnlyCollection<TResultSet2>(results[1].Cast<TResultSet2>().ToList()),
@@ -84,22 +84,22 @@ public static class MultiReadOnlyCollectionReadSqlAsyncCommands
     public static async Task<(ReadOnlyCollection<TResultSet1>, ReadOnlyCollection<TResultSet2>,
             ReadOnlyCollection<TResultSet3>, ReadOnlyCollection<TResultSet4>, ReadOnlyCollection<TResultSet5>)>
         QueryMultipleReadOnlyCollectionAsync<TResultSet1, TResultSet2, TResultSet3, TResultSet4, TResultSet5>(
-            this ICaeriusDbConnectionFactory connectionFactory,
+            this ICaeriusDbContext context,
             StoredProcedureParametersBuilder spParameters,
-            Func<SqlDataReader, TResultSet1> map1,
-            Func<SqlDataReader, TResultSet2> map2,
-            Func<SqlDataReader, TResultSet3> map3,
-            Func<SqlDataReader, TResultSet4> map4,
-            Func<SqlDataReader, TResultSet5> map5)
+            Func<SqlDataReader, TResultSet1> resultSet1,
+            Func<SqlDataReader, TResultSet2> resultSet2,
+            Func<SqlDataReader, TResultSet3> resultSet3,
+            Func<SqlDataReader, TResultSet4> resultSet4,
+            Func<SqlDataReader, TResultSet5> resultSet5)
         where TResultSet1 : class, ISpMapper<TResultSet1>
         where TResultSet2 : class, ISpMapper<TResultSet2>
         where TResultSet3 : class, ISpMapper<TResultSet3>
         where TResultSet4 : class, ISpMapper<TResultSet4>
         where TResultSet5 : class, ISpMapper<TResultSet5>
     {
-        var results =
-            await connectionFactory.ReadMultipleIReadOnlyCollectionResultSetsAsync(spParameters, map1, map2, map3, map4,
-                map5);
+        var results = await context
+            .ReadMultipleIReadOnlyCollectionResultSetsAsync(spParameters, resultSet1, resultSet2, resultSet3,
+                resultSet4, resultSet5);
 
         return (new ReadOnlyCollection<TResultSet1>(results[0].Cast<TResultSet1>().ToList()),
             new ReadOnlyCollection<TResultSet2>(results[1].Cast<TResultSet2>().ToList()),
@@ -109,14 +109,13 @@ public static class MultiReadOnlyCollectionReadSqlAsyncCommands
     }
 
     private static async Task<List<IReadOnlyCollection<object>>> ReadMultipleIReadOnlyCollectionResultSetsAsync(
-        this ICaeriusDbConnectionFactory connectionFactory,
-        StoredProcedureParametersBuilder spParameters,
+        this ICaeriusDbContext context, StoredProcedureParametersBuilder spParameters,
         params Func<SqlDataReader, object>[] mappers)
     {
         if (mappers.Length == 0)
             throw new ArgumentException("At least one mapper function must be provided.", nameof(mappers));
 
-        using var connection = connectionFactory.DbConnection();
+        using var connection = context.DbConnection();
         await using var command = await SqlCommandUtility.ExecuteSqlCommand(spParameters, connection);
         await using var reader = await command.ExecuteReaderAsync();
 

--- a/Src/Commands/Reads/SimpleReadSqlAsyncCommands.cs
+++ b/Src/Commands/Reads/SimpleReadSqlAsyncCommands.cs
@@ -6,7 +6,7 @@ using CaeriusNet.Utilities;
 namespace CaeriusNet.Commands.Reads;
 
 /// <summary>
-///     Provides asynchronous TSQL query execution methods extending <see cref="ICaeriusDbConnectionFactory" />.
+///     Provides asynchronous TSQL query execution methods extending <see cref="ICaeriusDbContext" />.
 /// </summary>
 public static class SimpleReadSqlAsyncCommands
 {
@@ -14,18 +14,17 @@ public static class SimpleReadSqlAsyncCommands
     ///     Executes a TSQL query asynchronously and returns the first result as a specified type.
     /// </summary>
     /// <typeparam name="TResultSet">The type of the result set.</typeparam>
-    /// <param name="connectionFactory">The database connection factory to create a connection.</param>
+    /// <param name="context">The database connection factory to create a connection.</param>
     /// <param name="spParameters">The stored procedure parameters builder containing the procedure name and parameters.</param>
     /// <returns>The first result of the query as the specified type mapped by <see cref="ISpMapper{T}" />.</returns>
     /// <exception cref="SqlException">Thrown when the query execution fails.</exception>
     public static async Task<TResultSet> FirstQueryAsync<TResultSet>(
-        this ICaeriusDbConnectionFactory connectionFactory,
-        StoredProcedureParametersBuilder spParameters)
+        this ICaeriusDbContext context, StoredProcedureParametersBuilder spParameters)
         where TResultSet : class, ISpMapper<TResultSet>
     {
         try
         {
-            var connection = connectionFactory.DbConnection();
+            var connection = context.DbConnection();
 
             using (connection)
             {
@@ -45,7 +44,7 @@ public static class SimpleReadSqlAsyncCommands
     ///     Executes a TSQL query asynchronously and returns all results as a read-only collection of a specified type.
     /// </summary>
     /// <typeparam name="TResultSet">The type of the result set.</typeparam>
-    /// <param name="connectionFactory">The database connection factory to create a connection.</param>
+    /// <param name="context">The database connection factory to create a connection.</param>
     /// <param name="spParameters">The stored procedure parameters builder containing the procedure name and parameters.</param>
     /// <returns>
     ///     A read-only collection of all results of the query as the specified type mapped by <see cref="ISpMapper{T}" />
@@ -53,12 +52,12 @@ public static class SimpleReadSqlAsyncCommands
     /// </returns>
     /// <exception cref="SqlException">Thrown when the query execution fails.</exception>
     public static async Task<ReadOnlyCollection<TResultSet>> QueryAsync<TResultSet>(
-        this ICaeriusDbConnectionFactory connectionFactory, StoredProcedureParametersBuilder spParameters)
+        this ICaeriusDbContext context, StoredProcedureParametersBuilder spParameters)
         where TResultSet : class, ISpMapper<TResultSet>
     {
         try
         {
-            var connection = connectionFactory.DbConnection();
+            var connection = context.DbConnection();
 
             using (connection)
             {
@@ -78,18 +77,17 @@ public static class SimpleReadSqlAsyncCommands
     ///     Executes a TSQL query asynchronously and returns all results as an enumerable of a specified type.
     /// </summary>
     /// <typeparam name="TResultSet">The type of the result set.</typeparam>
-    /// <param name="connectionFactory">The database connection factory to create a connection.</param>
+    /// <param name="context">The database connection factory to create a connection.</param>
     /// <param name="spParameters">The stored procedure parameters builder containing the procedure name and parameters.</param>
     /// <returns>An enumerable of all results of the query as the specified type mapped by <see cref="ISpMapper{T}" />.</returns>
     /// <exception cref="SqlException">Thrown when the query execution fails.</exception>
     public static async Task<IEnumerable<TResultSet>> EnumerableQueryAsync<TResultSet>(
-        this ICaeriusDbConnectionFactory connectionFactory,
-        StoredProcedureParametersBuilder spParameters)
+        this ICaeriusDbContext context, StoredProcedureParametersBuilder spParameters)
         where TResultSet : class, ISpMapper<TResultSet>
     {
         try
         {
-            var connection = connectionFactory.DbConnection();
+            var connection = context.DbConnection();
 
             using (connection)
             {
@@ -109,18 +107,17 @@ public static class SimpleReadSqlAsyncCommands
     ///     Executes a TSQL query asynchronously and returns all results as an immutable array of a specified type.
     /// </summary>
     /// <typeparam name="TResultSet">The type of the result set.</typeparam>
-    /// <param name="connectionFactory">The database connection factory to create a connection.</param>
+    /// <param name="context">The database connection factory to create a connection.</param>
     /// <param name="spParameters">The stored procedure parameters builder containing the procedure name and parameters.</param>
     /// <returns>An immutable array of all results of the query as the specified type mapped by <see cref="ISpMapper{T}" />.</returns>
     /// <exception cref="SqlException">Thrown when the query execution fails.</exception>
     public static async Task<ImmutableArray<TResultSet>> ImmutableQueryAsync<TResultSet>(
-        this ICaeriusDbConnectionFactory connectionFactory,
-        StoredProcedureParametersBuilder spParameters)
+        this ICaeriusDbContext context, StoredProcedureParametersBuilder spParameters)
         where TResultSet : class, ISpMapper<TResultSet>
     {
         try
         {
-            var connection = connectionFactory.DbConnection();
+            var connection = context.DbConnection();
 
             using (connection)
             {

--- a/Src/Commands/Writes/WriteSqlAsyncCommands.cs
+++ b/Src/Commands/Writes/WriteSqlAsyncCommands.cs
@@ -5,22 +5,22 @@ using CaeriusNet.Utilities;
 namespace CaeriusNet.Commands.Writes;
 
 /// <summary>
-///     Provides asynchronous TSQL command execution methods extending <see cref="ICaeriusDbConnectionFactory" />.
+///     Provides asynchronous TSQL command execution methods extending <see cref="ICaeriusDbContext" />.
 /// </summary>
 public static class WriteSqlAsyncCommands
 {
     /// <summary>
     ///     Executes a TSQL command that returns a single value asynchronously.
     /// </summary>
-    /// <param name="connectionFactory">The database connection factory to create a connection.</param>
+    /// <param name="context">The database connection factory to create a connection.</param>
     /// <param name="spParameters">The stored procedure parameters builder containing the procedure name and parameters.</param>
     /// <exception cref="Exception">Throws an exception if the command execution fails.</exception>
-    public static async Task<object?> ExecuteScalarAsync(this ICaeriusDbConnectionFactory connectionFactory,
+    public static async Task<object?> ExecuteScalarAsync(this ICaeriusDbContext context,
         StoredProcedureParametersBuilder spParameters)
     {
         try
         {
-            var connection = connectionFactory.DbConnection();
+            var connection = context.DbConnection();
 
             using (connection)
             {
@@ -38,22 +38,22 @@ public static class WriteSqlAsyncCommands
     /// <summary>
     ///     Executes a TSQL command that does not return a result set, but the number of rows affected, asynchronously.
     /// </summary>
-    /// <param name="connectionFactory">The database connection factory to create a connection.</param>
+    /// <param name="context">The database connection factory to create a connection.</param>
     /// <param name="spParameters">The stored procedure parameters builder containing the procedure name and parameters.</param>
     /// <returns>The number of rows affected.</returns>
     /// <exception cref="Exception">Throws an exception if the command execution fails.</exception>
-    public static async Task<int> ExecuteAsync(this ICaeriusDbConnectionFactory connectionFactory,
+    public static async Task<int> ExecuteAsync(this ICaeriusDbContext context,
         StoredProcedureParametersBuilder spParameters)
     {
         try
         {
-            var connection = connectionFactory.DbConnection();
+            var connection = context.DbConnection();
 
             using (connection)
             {
                 await using var command = await SqlCommandUtility.ExecuteSqlCommand(spParameters, connection);
-                var rowResults = await command.ExecuteNonQueryAsync();
-                return rowResults;
+                var resultRow = await command.ExecuteNonQueryAsync();
+                return resultRow;
             }
         }
         catch (SqlException ex)

--- a/Src/Extensions/CaeriusServiceCollectionExtensions.cs
+++ b/Src/Extensions/CaeriusServiceCollectionExtensions.cs
@@ -15,8 +15,6 @@ public static class CaeriusServiceCollectionExtensions
     /// <returns>The IServiceCollection for chaining.</returns>
     public static IServiceCollection RegisterCaeriusOrm(this IServiceCollection services, string connectionString)
     {
-        return services
-            .AddSingleton<ICaeriusDbConnectionFactory, CaeriusDbConnectionFactory>(_ =>
-                new CaeriusDbConnectionFactory(connectionString));
+        return services.AddSingleton<ICaeriusDbContext, CaeriusDbContext>(_ => new CaeriusDbContext(connectionString));
     }
 }

--- a/Src/Factories/CaeriusDbContext.cs
+++ b/Src/Factories/CaeriusDbContext.cs
@@ -3,7 +3,7 @@
 /// <summary>
 ///     Factory for creating database connections using a specified connection string.
 /// </summary>
-public sealed record CaeriusDbConnectionFactory(string ConnectionString) : ICaeriusDbConnectionFactory
+public sealed record CaeriusDbContext(string ConnectionString) : ICaeriusDbContext
 {
     /// <summary>
     ///     Creates and opens a database connection.

--- a/Src/Factories/ICaeriusDbContext.cs
+++ b/Src/Factories/ICaeriusDbContext.cs
@@ -3,7 +3,7 @@ namespace CaeriusNet.Factories;
 /// <summary>
 ///     Defines the interface for a factory that creates database connections.
 /// </summary>
-public interface ICaeriusDbConnectionFactory
+public interface ICaeriusDbContext
 {
     /// <summary>
     ///     Creates and returns a new database connection instance.


### PR DESCRIPTION
Updated the codebase to replace `ICaeriusDbConnectionFactory` with `ICaeriusDbContext` across multiple files to unify the database context usage. Adjusted method signatures and variable names accordingly for consistency and clarity in database operations. This change improves maintainability and aligns with the updated design pattern for handling database interactions.