### PR TITLE
Add caching support for stored procedures and utilities

### DIFF
--- a/.github/workflows/nuget-dotnet.yml
+++ b/.github/workflows/nuget-dotnet.yml
@@ -55,7 +55,7 @@ jobs:
           path: Src/
 
       - name: Restore dependencies
-        run: dotnet restore Src/CaeriusNet.csproj  # ← AJOUT DE CETTE ÉTAPE
+        run: dotnet restore Src/CaeriusNet.csproj
 
       - name: Pack NuGet Package
         run: dotnet pack Src/CaeriusNet.csproj --configuration Release --no-build --output ./output

--- a/Src/Builders/StoredProcedureParametersBuilder.cs
+++ b/Src/Builders/StoredProcedureParametersBuilder.cs
@@ -1,4 +1,6 @@
-﻿namespace CaeriusNet.Builders;
+﻿using static CaeriusNet.Utilities.CacheType;
+
+namespace CaeriusNet.Builders;
 
 /// <summary>
 ///     Builds the parameters for a stored procedure call, including support for Table-Valued Parameters (TVPs).
@@ -9,6 +11,10 @@ public sealed record StoredProcedureParametersBuilder(string ProcedureName, int 
     ///     Gets the list of TSQL parameters to be used in the stored procedure call.
     /// </summary>
     private List<SqlParameter> Parameters { get; } = [];
+
+    private string? CacheKey { get; set; }
+    private TimeSpan? CacheExpiration { get; set; }
+    private CacheType? CacheType { get; set; }
 
     /// <summary>
     ///     Adds a parameter to the stored procedure call.
@@ -51,11 +57,28 @@ public sealed record StoredProcedureParametersBuilder(string ProcedureName, int 
         return this;
     }
 
+    public StoredProcedureParametersBuilder AddFrozenCache(string cacheKey)
+    {
+        CacheKey = cacheKey;
+        CacheType = Frozen;
+        CacheExpiration = null;
+        return this;
+    }
+
+    // Ajout de l'option pour InMemoryCache avec expiration
+    public StoredProcedureParametersBuilder AddInMemoryCache(string cacheKey, TimeSpan expiration)
+    {
+        CacheKey = cacheKey;
+        CacheType = InMemory;
+        CacheExpiration = expiration;
+        return this;
+    }
+
     /// <summary>
     ///     Builds and returns a StoredProcedureParameters object containing all configured parameters.
     /// </summary>
     public StoredProcedureParameters Build()
     {
-        return new StoredProcedureParameters(ProcedureName, Capacity, Parameters);
+        return new StoredProcedureParameters(ProcedureName, Capacity, Parameters, CacheKey, CacheExpiration, CacheType);
     }
 }

--- a/Src/Caches/Caching.cs
+++ b/Src/Caches/Caching.cs
@@ -10,8 +10,7 @@ public sealed class Caching
 
     public static IReadOnlyDictionary<TKey, TValue> GetOrAdd<TKey, TValue>(
         string cacheKey,
-        Func<IReadOnlyDictionary<TKey, TValue>> dataRetriever)
-        where TKey : notnull
+        Func<IReadOnlyDictionary<TKey, TValue>> dataRetriever) where TKey : notnull
     {
         if (FrozenCache.TryGetValue(cacheKey, out var cached))
             return (IReadOnlyDictionary<TKey, TValue>)cached;
@@ -32,7 +31,7 @@ public sealed class Caching
             TimeSpan expiration)
         {
             if (MemoryCache.TryGetValue(cacheKey, out var cached))
-                return (IReadOnlyDictionary<TKey, TValue>)cached;
+                return (IReadOnlyDictionary<TKey, TValue>)cached!;
 
             var data = dataRetriever();
             var cacheEntry = MemoryCache.Set(cacheKey, data, expiration);

--- a/Src/CaeriusNet.csproj
+++ b/Src/CaeriusNet.csproj
@@ -9,11 +9,11 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-        <Version>9.0.0</Version>
+        <Version>9.0.1</Version>
         <Title>CaeriusNet</Title>
         <Authors>AriusII &amp; CaeriusNet</Authors>
         <Description>C# &amp; TSQL enchanced by performance Micro-ORM, Stored Procedure to DTO in µseconds !</Description>
-        <Copyright>2024</Copyright>
+        <Copyright>2025</Copyright>
         <PackageProjectUrl>https://caerius.net</PackageProjectUrl>
         <PackageTags>dapper, ef, orm, fast, stored, procedure</PackageTags>
     </PropertyGroup>

--- a/Src/Commands/Reads/SimpleReadSqlAsyncCommands.cs
+++ b/Src/Commands/Reads/SimpleReadSqlAsyncCommands.cs
@@ -1,3 +1,5 @@
+using CaeriusNet.Caches;
+
 namespace CaeriusNet.Commands.Reads;
 
 /// <summary>
@@ -14,24 +16,30 @@ public static class SimpleReadSqlAsyncCommands
     /// <returns>The first result of the query as the specified type mapped by <see cref="ISpMapper{T}" />.</returns>
     /// <exception cref="CaeriusSqlException">Thrown when the query execution fails.</exception>
     public static async Task<TResultSet> FirstQueryAsync<TResultSet>(
-        this ICaeriusDbContext context, StoredProcedureParameters spParameters)
+        this ICaeriusDbContext context,
+        StoredProcedureParameters spParameters)
         where TResultSet : class, ISpMapper<TResultSet>
     {
+        if (TryRetrieveResultSetFromCache(spParameters, out TResultSet? cachedResult) && cachedResult != null)
+            return cachedResult;
+
         try
         {
             var connection = context.DbConnection();
-
             using (connection)
             {
                 await using var command = await SqlCommandUtility.ExecuteSqlCommand(spParameters, connection);
                 await using var reader = await command.ExecuteReaderAsync();
-                var results = await SqlCommandUtility.SingleResultSet<TResultSet>(reader);
-                return results;
+                var result = await SqlCommandUtility.SingleResultSet<TResultSet>(reader);
+
+                StoreResultSetInCache(spParameters, result);
+
+                return result;
             }
         }
         catch (SqlException ex)
         {
-            throw new CaeriusSqlException($"Failed to execute stored procedure : {spParameters.ProcedureName} ::", ex);
+            throw new CaeriusSqlException($"Failed to execute stored procedure : {spParameters.ProcedureName}", ex);
         }
     }
 
@@ -42,29 +50,32 @@ public static class SimpleReadSqlAsyncCommands
     /// <param name="context">The database connection factory to create a connection.</param>
     /// <param name="spParameters">The stored procedure parameters builder containing the procedure name and parameters.</param>
     /// <returns>
-    ///     A read-only collection of all results of the query as the specified type mapped by <see cref="ISpMapper{T}" />
-    ///     .
+    ///     A read-only collection of all results of the query as the specified type mapped by <see cref="ISpMapper{T}" />.
     /// </returns>
     /// <exception cref="CaeriusSqlException">Thrown when the query execution fails.</exception>
     public static async Task<ReadOnlyCollection<TResultSet>> QueryAsync<TResultSet>(
         this ICaeriusDbContext context, StoredProcedureParameters spParameters)
         where TResultSet : class, ISpMapper<TResultSet>
     {
+        if (TryRetrieveResultSetFromCache(spParameters, out ReadOnlyCollection<TResultSet>? cachedResult) &&
+            cachedResult != null) return cachedResult;
+
         try
         {
             var connection = context.DbConnection();
-
             using (connection)
             {
                 await using var command = await SqlCommandUtility.ExecuteSqlCommand(spParameters, connection);
                 await using var reader = await command.ExecuteReaderAsync();
                 var results = await SqlCommandUtility.ResultsSets<TResultSet>(spParameters, reader);
+
+                StoreResultSetInCache(spParameters, results.AsReadOnly());
                 return results.AsReadOnly();
             }
         }
         catch (SqlException ex)
         {
-            throw new CaeriusSqlException($"Failed to execute stored procedure : {spParameters.ProcedureName} ::", ex);
+            throw new CaeriusSqlException($"Failed to execute stored procedure : {spParameters.ProcedureName}", ex);
         }
     }
 
@@ -80,21 +91,25 @@ public static class SimpleReadSqlAsyncCommands
         this ICaeriusDbContext context, StoredProcedureParameters spParameters)
         where TResultSet : class, ISpMapper<TResultSet>
     {
+        if (TryRetrieveResultSetFromCache(spParameters, out IEnumerable<TResultSet>? cachedResult) &&
+            cachedResult != null) return cachedResult;
+
         try
         {
             var connection = context.DbConnection();
-
             using (connection)
             {
                 await using var command = await SqlCommandUtility.ExecuteSqlCommand(spParameters, connection);
                 await using var reader = await command.ExecuteReaderAsync();
                 var results = await SqlCommandUtility.ResultsSets<TResultSet>(spParameters, reader);
+
+                StoreResultSetInCache(spParameters, results.AsEnumerable());
                 return results.AsEnumerable();
             }
         }
         catch (SqlException ex)
         {
-            throw new CaeriusSqlException($"Failed to execute stored procedure : {spParameters.ProcedureName} ;", ex);
+            throw new CaeriusSqlException($"Failed to execute stored procedure : {spParameters.ProcedureName}", ex);
         }
     }
 
@@ -107,29 +122,106 @@ public static class SimpleReadSqlAsyncCommands
     /// <returns>An immutable array of all results of the query as the specified type mapped by <see cref="ISpMapper{T}" />.</returns>
     /// <exception cref="CaeriusSqlException">Thrown when the query execution fails.</exception>
     public static async Task<ImmutableArray<TResultSet>> ImmutableQueryAsync<TResultSet>(
-        this ICaeriusDbContext context, StoredProcedureParameters spParameters)
+        this ICaeriusDbContext context,
+        StoredProcedureParameters spParameters)
         where TResultSet : class, ISpMapper<TResultSet>
     {
+        if (TryRetrieveResultSetFromCache(spParameters, out ImmutableArray<TResultSet> cachedResult) &&
+            cachedResult != null)
+            return cachedResult;
+
         try
         {
             var connection = context.DbConnection();
-
             using (connection)
             {
                 await using var command = await SqlCommandUtility.ExecuteSqlCommand(spParameters, connection);
                 await using var reader = await command.ExecuteReaderAsync();
 
                 var results = ImmutableArray.CreateBuilder<TResultSet>(spParameters.Capacity);
-
                 while (await reader.ReadAsync())
                     results.AddRange(TResultSet.MapFromDataReader(reader));
 
+                StoreResultSetInCache(spParameters, results.ToImmutable());
                 return results.ToImmutable();
             }
         }
         catch (SqlException ex)
         {
-            throw new CaeriusSqlException($"Failed to execute stored procedure : {spParameters.ProcedureName} ;", ex);
+            throw new CaeriusSqlException($"Failed to execute stored procedure : {spParameters.ProcedureName}", ex);
+        }
+    }
+
+    private static bool TryRetrieveResultSetFromCache<TResultSet>(
+        StoredProcedureParameters spParameters,
+        out TResultSet? resultSet)
+        where TResultSet : notnull
+    {
+        resultSet = default;
+
+        if (string.IsNullOrEmpty(spParameters.CacheKey) || spParameters.CacheType == null)
+            return false;
+
+        switch (spParameters.CacheType)
+        {
+            case CacheType.InMemory:
+                var cachedInMemory = Caching.InMemoryCacheManager.GetOrAdd(
+                    spParameters.CacheKey,
+                    () => new Dictionary<TResultSet, TResultSet>(),
+                    spParameters.CacheExpiration!.Value);
+                if (cachedInMemory.Count > 0)
+                {
+                    resultSet = cachedInMemory.Keys.First();
+                    return true;
+                }
+
+                break;
+
+            case CacheType.Frozen:
+                var cachedFrozen = Caching.GetOrAdd(
+                    spParameters.CacheKey,
+                    () => new Dictionary<TResultSet, TResultSet>());
+                if (cachedFrozen.Count > 0)
+                {
+                    resultSet = cachedFrozen.Keys.First();
+                    return true;
+                }
+
+                break;
+            case null:
+                break;
+            default:
+                throw new ArgumentOutOfRangeException();
+        }
+
+        return false;
+    }
+
+    private static void StoreResultSetInCache<TResultSet>(
+        StoredProcedureParameters spParameters,
+        TResultSet resultSet)
+        where TResultSet : notnull
+    {
+        if (string.IsNullOrEmpty(spParameters.CacheKey) || spParameters.CacheType == null) return;
+
+        switch (spParameters.CacheType)
+        {
+            case CacheType.InMemory:
+                Caching.InMemoryCacheManager.GetOrAdd(
+                    spParameters.CacheKey,
+                    () => new Dictionary<TResultSet, TResultSet> { [resultSet] = resultSet },
+                    spParameters.CacheExpiration!.Value);
+                break;
+
+            case CacheType.Frozen:
+                Caching.GetOrAdd(
+                    spParameters.CacheKey,
+                    () => new Dictionary<TResultSet, TResultSet> { [resultSet] = resultSet });
+                break;
+            case null:
+                break;
+            default:
+                throw new ArgumentOutOfRangeException();
         }
     }
 }

--- a/Src/Extensions/CaeriusCacheExtensions.cs
+++ b/Src/Extensions/CaeriusCacheExtensions.cs
@@ -25,4 +25,54 @@ public static class CaeriusCacheExtensions
             return result.ToDictionary(x => x, x => x);
         }, expiration).Values.ToList().AsReadOnly();
     }
+
+    public static async Task<IEnumerable<TResultSet>> WithFrozenCaching<TResultSet>(
+        this Task<IEnumerable<TResultSet>> task, string cacheKey)
+        where TResultSet : class
+    {
+        return Caching.GetOrAdd(cacheKey, () =>
+        {
+            var result = task.GetAwaiter().GetResult();
+            return result.ToDictionary(x => x, x => x);
+        }).Values.ToList();
+    }
+
+    public static async Task<IEnumerable<TResultSet>> WithInMemoryCaching<TResultSet>(
+        this Task<IEnumerable<TResultSet>> task, string cacheKey, TimeSpan expiration)
+        where TResultSet : class
+    {
+        return Caching.InMemoryCacheManager.GetOrAdd(cacheKey, () =>
+        {
+            var result = task.GetAwaiter().GetResult();
+            return result.ToDictionary(x => x, x => x);
+        }, expiration).Values.ToList();
+    }
+
+    public static async Task<ImmutableArray<TResultSet>> WithFrozenCaching<TResultSet>(
+        this Task<ImmutableArray<TResultSet>> task, string cacheKey)
+        where TResultSet : class
+    {
+        return
+        [
+            ..Caching.GetOrAdd(cacheKey, () =>
+            {
+                var result = task.GetAwaiter().GetResult();
+                return result.ToDictionary(x => x, x => x);
+            }).Values
+        ];
+    }
+
+    public static async Task<ImmutableArray<TResultSet>> WithInMemoryCaching<TResultSet>(
+        this Task<ImmutableArray<TResultSet>> task, string cacheKey, TimeSpan expiration)
+        where TResultSet : class
+    {
+        return
+        [
+            ..Caching.InMemoryCacheManager.GetOrAdd(cacheKey, () =>
+            {
+                var result = task.GetAwaiter().GetResult();
+                return result.ToDictionary(x => x, x => x);
+            }, expiration).Values
+        ];
+    }
 }

--- a/Src/Mappers/StoredProcedureParameters.cs
+++ b/Src/Mappers/StoredProcedureParameters.cs
@@ -3,4 +3,10 @@
 /// <summary>
 ///     Represents the parameters to be passed to a stored procedure.
 /// </summary>
-public sealed record StoredProcedureParameters(string ProcedureName, int Capacity, List<SqlParameter> Parameters);
+public sealed record StoredProcedureParameters(
+    string ProcedureName,
+    int Capacity,
+    List<SqlParameter> Parameters,
+    string? CacheKey,
+    TimeSpan? CacheExpiration,
+    CacheType? CacheType);

--- a/Src/Utilities/CacheType.cs
+++ b/Src/Utilities/CacheType.cs
@@ -1,0 +1,7 @@
+﻿namespace CaeriusNet.Utilities;
+
+public enum CacheType
+{
+    Frozen,
+    InMemory
+}


### PR DESCRIPTION
Added in-memory and frozen caching features for stored procedure results. Extended `StoredProcedureParameters` to include caching options. Introduced helper methods to query and store cached results efficiently. Updated project version to 9.0.1.