### PR TITLE
Add example project and support for Aspire Redis caching

### DIFF
--- a/CaeriusNet.sln
+++ b/CaeriusNet.sln
@@ -12,6 +12,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "SourceGenerators", "SourceG
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CaeriusNet.Generator", "SourceGenerators\CaeriusNet.Generator.csproj", "{33F93DF1-EDCF-43BE-9F45-14D011A31CAB}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Exemples", "Exemples", "{A2D9BD40-C26F-4C91-8AF5-5355DE9DC9A8}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CaeriusNet.Exemples", "Exemples\CaeriusNet.Exemples\CaeriusNet.Exemples.csproj", "{3D128555-AEBC-4C49-B638-5D1C922D9370}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,6 +25,7 @@ Global
 		{354375C9-6A8E-40E6-9092-092CA6535402} = {4041333D-92A9-4DFC-A224-7BD818142763}
 		{0341C72C-B83F-4DB9-BC2E-86CBCCAFC9A2} = {CE57F0A6-B283-42CF-B6C3-5E51011D51B3}
 		{33F93DF1-EDCF-43BE-9F45-14D011A31CAB} = {0BC70258-588F-4EBA-98EB-085CB05A472D}
+		{3D128555-AEBC-4C49-B638-5D1C922D9370} = {A2D9BD40-C26F-4C91-8AF5-5355DE9DC9A8}
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{354375C9-6A8E-40E6-9092-092CA6535402}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -35,5 +40,9 @@ Global
 		{33F93DF1-EDCF-43BE-9F45-14D011A31CAB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{33F93DF1-EDCF-43BE-9F45-14D011A31CAB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{33F93DF1-EDCF-43BE-9F45-14D011A31CAB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3D128555-AEBC-4C49-B638-5D1C922D9370}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3D128555-AEBC-4C49-B638-5D1C922D9370}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3D128555-AEBC-4C49-B638-5D1C922D9370}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3D128555-AEBC-4C49-B638-5D1C922D9370}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/Exemples/CaeriusNet.Exemples/CaeriusNet.Exemples.csproj
+++ b/Exemples/CaeriusNet.Exemples/CaeriusNet.Exemples.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<TargetFramework>net9.0</TargetFramework>
+		<LangVersion>13</LangVersion>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+		<PublishAot>true</PublishAot>
+		<IsAotCompatible>true</IsAotCompatible>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="CaeriusNet" Version="9.2.3"/>
+		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.5"/>
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.5"/>
+	</ItemGroup>
+
+</Project>

--- a/Exemples/CaeriusNet.Exemples/Interfaces/IUsersRepositories.cs
+++ b/Exemples/CaeriusNet.Exemples/Interfaces/IUsersRepositories.cs
@@ -1,0 +1,9 @@
+﻿using CaeriusNet.Exemples.Models.Dtos;
+
+namespace CaeriusNet.Exemples.Interfaces;
+
+public interface IUsersRepositories
+{
+	Task<IEnumerable<ManualUsersDto>> GetAllUsersAsync();
+	Task<SrcGenUsersDto> GetAllUsersInformationAsync();
+}

--- a/Exemples/CaeriusNet.Exemples/Models/Dtos/ManualUsersDto.cs
+++ b/Exemples/CaeriusNet.Exemples/Models/Dtos/ManualUsersDto.cs
@@ -1,0 +1,18 @@
+﻿using CaeriusNet.Mappers;
+using Microsoft.Data.SqlClient;
+
+namespace CaeriusNet.Exemples.Models.Dtos;
+
+public sealed record ManualUsersDto(int UserId, Guid UserGuid, string Username, ushort UserAge)
+	: ISpMapper<ManualUsersDto>
+{
+	public static ManualUsersDto MapFromDataReader(SqlDataReader reader)
+	{
+		return new ManualUsersDto(
+			reader.GetInt32(0),
+			reader.GetGuid(1),
+			reader.GetString(2),
+			(ushort)reader.GetInt16(3)
+		);
+	}
+}

--- a/Exemples/CaeriusNet.Exemples/Models/Dtos/SrcGenUsersDto.cs
+++ b/Exemples/CaeriusNet.Exemples/Models/Dtos/SrcGenUsersDto.cs
@@ -1,0 +1,6 @@
+﻿using CaeriusNet.Attributes;
+
+namespace CaeriusNet.Exemples.Models.Dtos;
+
+[GenerateDto]
+public sealed partial record SrcGenUsersDto(int UserId, Guid UserGuid, string Username);

--- a/Exemples/CaeriusNet.Exemples/Models/Tvps/ManualUsersAgeTvp.cs
+++ b/Exemples/CaeriusNet.Exemples/Models/Tvps/ManualUsersAgeTvp.cs
@@ -1,0 +1,17 @@
+﻿using System.Data;
+using CaeriusNet.Mappers;
+
+namespace CaeriusNet.Exemples.Models.Tvps;
+
+public sealed record ManualUsersAgeTvp(int UsersId) : ITvpMapper<ManualUsersAgeTvp>
+{
+	public DataTable MapAsDataTable(IEnumerable<ManualUsersAgeTvp> items)
+	{
+		var dataTable = new DataTable("UsersAge");
+		dataTable.Columns.Add("UsersId", typeof(int));
+
+		foreach (var item in items) dataTable.Rows.Add(item.UsersId);
+
+		return dataTable;
+	}
+}

--- a/Exemples/CaeriusNet.Exemples/Models/Tvps/SrcGenUsersAgeTvp.cs
+++ b/Exemples/CaeriusNet.Exemples/Models/Tvps/SrcGenUsersAgeTvp.cs
@@ -1,0 +1,3 @@
+﻿namespace CaeriusNet.Exemples.Models.Tvps;
+
+public sealed record SrcGenUsersAgeTvp;

--- a/Exemples/CaeriusNet.Exemples/Program.cs
+++ b/Exemples/CaeriusNet.Exemples/Program.cs
@@ -1,0 +1,21 @@
+﻿using CaeriusNet.Exemples.Interfaces;
+using CaeriusNet.Exemples.Repositories;
+using CaeriusNet.Extensions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+var configuration = new ConfigurationBuilder()
+	.AddJsonFile("appsettings.json", false, false)
+	.Build();
+
+var mssqlCnx = configuration.GetConnectionString("Database")!;
+
+var redisCnx = configuration.GetConnectionString("Redis")!;
+
+var serviceCollection = new ServiceCollection()
+	.AddCaeriusNet(mssqlCnx)
+	.AddCaeriusRedisCache(redisCnx)
+	.AddCaeriusLoggingConsole()
+	.AddScoped<IUsersRepositories, UsersRepositories>();
+
+var serviceProvider = serviceCollection.BuildServiceProvider();

--- a/Exemples/CaeriusNet.Exemples/Repositories/UsersRepositories.cs
+++ b/Exemples/CaeriusNet.Exemples/Repositories/UsersRepositories.cs
@@ -1,0 +1,26 @@
+﻿using CaeriusNet.Builders;
+using CaeriusNet.Commands.Reads;
+using CaeriusNet.Exemples.Interfaces;
+using CaeriusNet.Exemples.Models.Dtos;
+using CaeriusNet.Factories;
+
+namespace CaeriusNet.Exemples.Repositories;
+
+public sealed record UsersRepositories(ICaeriusDbContext DbContext) : IUsersRepositories
+{
+	public async Task<IEnumerable<ManualUsersDto>> GetAllUsersAsync()
+	{
+		var storedProcedureParameters = new StoredProcedureParametersBuilder("Users.usp_get_all_users").Build();
+
+		var dbResult = await DbContext.QueryAsIEnumerableAsync<ManualUsersDto>(storedProcedureParameters);
+		return dbResult;
+	}
+
+	public async Task<SrcGenUsersDto> GetAllUsersInformationAsync()
+	{
+		var spParam = new StoredProcedureParametersBuilder("Users.usp_get_all_users_information").Build();
+
+		var dbResult = await DbContext.FirstQueryAsync<SrcGenUsersDto>(spParam);
+		return dbResult!;
+	}
+}

--- a/Exemples/CaeriusNet.Exemples/appsettings.json
+++ b/Exemples/CaeriusNet.Exemples/appsettings.json
@@ -1,0 +1,16 @@
+﻿{
+	"Logging": {
+		"LogLevel": {
+			"Default": "Debug",
+			"System": "Information",
+			"Microsoft": "Information"
+		}
+	},
+	"ConnectionStrings": {
+		"Database": "Server=192.168.1.63,1433;User Id=sa;Password=Caerius123.;Database=Demo;Trusted_Connection=True;MultipleActiveResultSets=true;Encrypt=false"
+	},
+	"Redis": {
+		"Hote": "localhost",
+		"Port": 6379
+	}
+}

--- a/SourceGenerators/CaeriusNet.Generator.csproj
+++ b/SourceGenerators/CaeriusNet.Generator.csproj
@@ -25,8 +25,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" PrivateAssets="all"/>
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.13.0" PrivateAssets="all"/>
+		<PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="4.14.0" PrivateAssets="all"/>
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" PrivateAssets="all"/>
 	</ItemGroup>
 
 	<ItemGroup>

--- a/SourceGenerators/Utils/TypeDetector.cs
+++ b/SourceGenerators/Utils/TypeDetector.cs
@@ -91,7 +91,8 @@ public static class TypeDetector
 	/// <param name="typeSyntax">The type syntax (optional).</param>
 	/// <param name="nullableAnnotation">The type's nullable annotation (optional).</param>
 	/// <returns>True if the type can accept null, otherwise False.</returns>
-	public static bool IsTypeNullable(ITypeSymbol type, TypeSyntax? typeSyntax = null, NullableAnnotation? nullableAnnotation = null)
+	public static bool IsTypeNullable(ITypeSymbol type, TypeSyntax? typeSyntax = null,
+		NullableAnnotation? nullableAnnotation = null)
 	{
 		// 1. Check for explicit nullable annotation
 		if (nullableAnnotation is NullableAnnotation.Annotated)

--- a/Src/Attributes/GenerateDtoAttribute.cs
+++ b/Src/Attributes/GenerateDtoAttribute.cs
@@ -36,4 +36,6 @@
 ///     3. The generated <c>ISpMapper&lt;T&gt;</c> implementation appears at compile time.
 /// </para>
 [AttributeUsage(AttributeTargets.Class, Inherited = false)]
-public sealed class GenerateDtoAttribute : Attribute {}
+public sealed class GenerateDtoAttribute : Attribute
+{
+}

--- a/Src/Builders/StoredProcedureParametersBuilder.cs
+++ b/Src/Builders/StoredProcedureParametersBuilder.cs
@@ -62,7 +62,8 @@ public sealed record StoredProcedureParametersBuilder(string ProcedureName, int 
 	/// <param name="expiration">Optional expiration time for the cache. Defaults to null for no expiration.</param>
 	/// <param name="cacheType">The type of cache strategy to use. Defaults to <see cref="CacheType.InMemory" />.</param>
 	/// <returns>The <see cref="StoredProcedureParametersBuilder" /> instance for chaining.</returns>
-	public StoredProcedureParametersBuilder AddCache(string cacheKey, TimeSpan? expiration = null, CacheType cacheType = InMemory)
+	public StoredProcedureParametersBuilder AddCache(string cacheKey, TimeSpan? expiration = null,
+		CacheType cacheType = InMemory)
 	{
 		_cacheType = cacheType;
 		_cacheKey = cacheKey;
@@ -119,6 +120,28 @@ public sealed record StoredProcedureParametersBuilder(string ProcedureName, int 
 	}
 
 	/// <summary>
+	///     Adds Aspire Redis distributed cache support for the stored procedure call, using the .NET Aspire
+	///     Redis integration.
+	/// </summary>
+	/// <param name="cacheKey">
+	///     The unique key used to store and access the cached result in the Aspire Redis distributed cache.
+	/// </param>
+	/// <param name="expiration">
+	///     The expiration time of the cached data. This value is optional, and a default expiration may be used
+	///     if not specified.
+	/// </param>
+	/// <returns>
+	///     The <see cref="StoredProcedureParametersBuilder" /> instance for chaining.
+	/// </returns>
+	public StoredProcedureParametersBuilder AddAspireRedisCache(string cacheKey, TimeSpan? expiration = null)
+	{
+		_cacheType = AspireRedis;
+		_cacheKey = cacheKey;
+		_cacheExpiration = expiration;
+		return this;
+	}
+
+	/// <summary>
 	///     Builds and returns a <see cref="StoredProcedureParameters" /> object containing all configured parameters.
 	/// </summary>
 	/// <returns>
@@ -127,6 +150,7 @@ public sealed record StoredProcedureParametersBuilder(string ProcedureName, int 
 	/// </returns>
 	public StoredProcedureParameters Build()
 	{
-		return new StoredProcedureParameters(ProcedureName, Capacity, Parameters, _cacheKey, _cacheExpiration, _cacheType);
+		return new StoredProcedureParameters(ProcedureName, Capacity, Parameters, _cacheKey, _cacheExpiration,
+			_cacheType);
 	}
 }

--- a/Src/Caches/AspireRedisCacheManager.cs
+++ b/Src/Caches/AspireRedisCacheManager.cs
@@ -1,0 +1,118 @@
+﻿using CaeriusNet.Logging;
+using Microsoft.Extensions.Caching.Distributed;
+
+namespace CaeriusNet.Caches;
+
+/// <summary>
+///     Provides methods to manage Redis-based distributed cache using .NET Aspire integration.
+/// </summary>
+internal sealed class AspireRedisCacheManager
+{
+	private static AspireRedisCacheManager? _instance;
+	private static readonly ICaeriusLogger? Logger = LoggerProvider.GetLogger();
+	private readonly IDistributedCache _distributedCache;
+
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="AspireRedisCacheManager" /> class.
+    /// </summary>
+    /// <param name="distributedCache">The distributed cache instance.</param>
+    public AspireRedisCacheManager(IDistributedCache distributedCache)
+	{
+		_distributedCache = distributedCache;
+		_instance = this;
+		Logger?.LogInformation(LogCategory.Redis, "AspireRedisDistribuedCacheManager initialized successfully.");
+	}
+
+    /// <summary>
+    ///     Checks if the AspireRedisCacheManager is initialized.
+    /// </summary>
+    /// <returns>True if the manager is initialized, otherwise False.</returns>
+    internal static bool IsInitialized()
+	{
+		return _instance != null;
+	}
+
+    /// <summary>
+    ///     Stores a value in the Redis distributed cache.
+    /// </summary>
+    /// <typeparam name="T">The type of value to store in the cache.</typeparam>
+    /// <param name="cacheKey">The unique key to identify the value in the cache.</param>
+    /// <param name="value">The value to store in the cache.</param>
+    /// <param name="expiration">The validity duration of the value in the cache before expiration.</param>
+    internal static void Store<T>(string cacheKey, T value, TimeSpan? expiration)
+	{
+		if (_instance == null)
+		{
+			Logger?.LogWarning(LogCategory.Redis,
+				$"Attempt to store in Aspire Redis with key '{cacheKey}' while the manager is not initialized.");
+			return;
+		}
+
+		try
+		{
+			Logger?.LogDebug(LogCategory.Redis, $"Storing in Aspire Redis with key '{cacheKey}'...");
+			var serialized = JsonSerializer.Serialize(value);
+
+			var options = new DistributedCacheEntryOptions();
+			if (expiration.HasValue) options.AbsoluteExpirationRelativeToNow = expiration;
+
+			_instance._distributedCache.SetString(cacheKey, serialized, options);
+
+			Logger?.LogInformation(LogCategory.Redis,
+				$"Value stored in Aspire Redis with key '{cacheKey}' and expiration {(expiration.HasValue ? expiration.Value.ToString() : "unlimited")}");
+		}
+		catch (Exception ex)
+		{
+			Logger?.LogError(LogCategory.Redis, $"Error while storing in Aspire Redis with key '{cacheKey}'", ex);
+		}
+	}
+
+    /// <summary>
+    ///     Attempts to retrieve a cached value from Redis distributed cache.
+    /// </summary>
+    /// <typeparam name="T">The expected type of the cached value.</typeparam>
+    /// <param name="cacheKey">The unique key associated with the value in the cache.</param>
+    /// <param name="value">The output parameter where the cached value will be stored if found.</param>
+    /// <returns>
+    ///     True if the value is found in the cache and its type matches the specified type <typeparamref name="T" />;
+    ///     otherwise, False.
+    /// </returns>
+    internal static bool TryGet<T>(string cacheKey, out T? value)
+	{
+		value = default;
+		if (_instance == null)
+		{
+			Logger?.LogWarning(LogCategory.Redis,
+				$"Attempt to retrieve from Aspire Redis with key '{cacheKey}' while the manager is not initialized.");
+			return false;
+		}
+
+		try
+		{
+			Logger?.LogDebug(LogCategory.Redis, $"Retrieving from Aspire Redis with key '{cacheKey}'...");
+			var cached = _instance._distributedCache.GetString(cacheKey);
+
+			if (cached == null)
+			{
+				Logger?.LogDebug(LogCategory.Redis, $"No value found in Aspire Redis for key '{cacheKey}'");
+				return false;
+			}
+
+			value = JsonSerializer.Deserialize<T>(cached);
+			var success = value != null;
+
+			if (success)
+				Logger?.LogInformation(LogCategory.Redis,
+					$"Value successfully retrieved from Aspire Redis for key '{cacheKey}'");
+			else
+				Logger?.LogWarning(LogCategory.Redis, $"Deserialization failed for key '{cacheKey}'");
+
+			return success;
+		}
+		catch (Exception ex)
+		{
+			Logger?.LogError(LogCategory.Redis, $"Error while retrieving from Aspire Redis with key '{cacheKey}'", ex);
+			return false;
+		}
+	}
+}

--- a/Src/Caches/FrozenCacheManager.cs
+++ b/Src/Caches/FrozenCacheManager.cs
@@ -25,8 +25,9 @@ internal static class FrozenCacheManager
 		{
 			if (_frozenCache.ContainsKey(cacheKey))
 			{
-				Logger?.LogDebug(LogCategory.FrozenCache, $"Key '{cacheKey}' already exists in frozen cache. Ignoring store operation.");
-				return; 
+				Logger?.LogDebug(LogCategory.FrozenCache,
+					$"Key '{cacheKey}' already exists in frozen cache. Ignoring store operation.");
+				return;
 			}
 
 			var mutableCache = new ConcurrentDictionary<string, object>(_frozenCache) { [cacheKey] = value! };
@@ -52,7 +53,8 @@ internal static class FrozenCacheManager
 		if (_frozenCache.TryGetValue(cacheKey, out var cached) && cached is T typedValue)
 		{
 			value = typedValue;
-			Logger?.LogInformation(LogCategory.FrozenCache, $"Value successfully retrieved from frozen cache for key '{cacheKey}'");
+			Logger?.LogInformation(LogCategory.FrozenCache,
+				$"Value successfully retrieved from frozen cache for key '{cacheKey}'");
 			return true;
 		}
 

--- a/Src/Caches/InMemoryCacheManager.cs
+++ b/Src/Caches/InMemoryCacheManager.cs
@@ -22,7 +22,8 @@ internal static class InMemoryCacheManager
 	{
 		Logger?.LogDebug(LogCategory.InMemoryCache, $"Storing in memory cache with key '{cacheKey}'...");
 		MemoryCache.Set(cacheKey, value!, expiration);
-		Logger?.LogInformation(LogCategory.InMemoryCache, $"Value stored in memory cache with key '{cacheKey}' and expiration of {expiration}");
+		Logger?.LogInformation(LogCategory.InMemoryCache,
+			$"Value stored in memory cache with key '{cacheKey}' and expiration of {expiration}");
 	}
 
 	/// <summary>
@@ -44,7 +45,8 @@ internal static class InMemoryCacheManager
 		if (MemoryCache.TryGetValue(cacheKey, out var cached) && cached is T typedValue)
 		{
 			value = typedValue;
-			Logger?.LogInformation(LogCategory.InMemoryCache, $"Value successfully retrieved from memory cache for key '{cacheKey}'");
+			Logger?.LogInformation(LogCategory.InMemoryCache,
+				$"Value successfully retrieved from memory cache for key '{cacheKey}'");
 			return true;
 		}
 

--- a/Src/Caches/RedisCacheManager.cs
+++ b/Src/Caches/RedisCacheManager.cs
@@ -3,7 +3,7 @@
 namespace CaeriusNet.Caches;
 
 /// <summary>
-///	 Provides methods to manage Redis-based distributed cache.
+///     Provides methods to manage Redis-based distributed cache.
 /// </summary>
 internal static class RedisCacheManager
 {
@@ -13,7 +13,7 @@ internal static class RedisCacheManager
 	private static readonly ICaeriusLogger? Logger = LoggerProvider.GetLogger();
 
 	/// <summary>
-	///	 Initializes the Redis cache manager with the provided connection string.
+	///     Initializes the Redis cache manager with the provided connection string.
 	/// </summary>
 	/// <param name="connectionString">The connection string to the Redis server.</param>
 	/// <returns>True if initialization succeeded, otherwise False.</returns>
@@ -45,7 +45,7 @@ internal static class RedisCacheManager
 	}
 
 	/// <summary>
-	///	 Checks if the Redis cache manager is initialized.
+	///     Checks if the Redis cache manager is initialized.
 	/// </summary>
 	/// <returns>True if the manager is initialized, otherwise False.</returns>
 	internal static bool IsInitialized()
@@ -54,19 +54,20 @@ internal static class RedisCacheManager
 	}
 
 	/// <summary>
-	///	 Stores a value in the Redis cache.
+	///     Stores a value in the Redis cache.
 	/// </summary>
 	/// <typeparam name="T">The type of value to store in the cache.</typeparam>
 	/// <param name="cacheKey">The unique key to identify the value in the cache.</param>
 	/// <param name="value">The value to store in the cache.</param>
 	/// <param name="expiration">The validity duration of the value in the cache before expiration.</param>
 	/// <returns>True if storage was successful, otherwise False.</returns>
-	internal static bool Store<T>(string cacheKey, T value, TimeSpan? expiration)
+	internal static void Store<T>(string cacheKey, T value, TimeSpan? expiration)
 	{
 		if (!_isInitialized || _database == null)
 		{
-			Logger?.LogWarning(LogCategory.Redis, $"Attempt to store in Redis with key '{cacheKey}' while Redis is not initialized.");
-			return false;
+			Logger?.LogWarning(LogCategory.Redis,
+				$"Attempt to store in Redis with key '{cacheKey}' while Redis is not initialized.");
+			return;
 		}
 
 		try
@@ -76,34 +77,34 @@ internal static class RedisCacheManager
 			var result = _database.StringSet(cacheKey, serialized, expiration);
 
 			if (result)
-				Logger?.LogInformation(LogCategory.Redis, $"Value stored in Redis with key '{cacheKey}' and expiration {(expiration.HasValue ? expiration.Value.ToString() : "unlimited")}");
+				Logger?.LogInformation(LogCategory.Redis,
+					$"Value stored in Redis with key '{cacheKey}' and expiration {(expiration.HasValue ? expiration.Value.ToString() : "unlimited")}");
 			else
 				Logger?.LogWarning(LogCategory.Redis, $"Failed to store value in Redis with key '{cacheKey}'");
-
-			return result;
 		}
 		catch (Exception ex)
 		{
 			Logger?.LogError(LogCategory.Redis, $"Error while storing in Redis with key '{cacheKey}'", ex);
-			return false;
 		}
 	}
 
 	/// <summary>
-	///	 Attempts to retrieve a cached value from Redis.
+	///     Attempts to retrieve a cached value from Redis.
 	/// </summary>
 	/// <typeparam name="T">The expected type of the cached value.</typeparam>
 	/// <param name="cacheKey">The unique key associated with the value in the cache.</param>
 	/// <param name="value">The output parameter where the cached value will be stored if found.</param>
 	/// <returns>
-	///	 True if the value is found in the cache and its type matches the specified type <typeparamref name="T"/>; otherwise, False.
+	///     True if the value is found in the cache and its type matches the specified type <typeparamref name="T" />;
+	///     otherwise, False.
 	/// </returns>
 	internal static bool TryGet<T>(string cacheKey, out T? value)
 	{
 		value = default;
 		if (!_isInitialized || _database == null)
 		{
-			Logger?.LogWarning(LogCategory.Redis, $"Attempt to retrieve from Redis with key '{cacheKey}' while Redis is not initialized.");
+			Logger?.LogWarning(LogCategory.Redis,
+				$"Attempt to retrieve from Redis with key '{cacheKey}' while Redis is not initialized.");
 			return false;
 		}
 
@@ -122,7 +123,8 @@ internal static class RedisCacheManager
 			var success = value != null;
 
 			if (success)
-				Logger?.LogInformation(LogCategory.Redis, $"Value successfully retrieved from Redis for key '{cacheKey}'");
+				Logger?.LogInformation(LogCategory.Redis,
+					$"Value successfully retrieved from Redis for key '{cacheKey}'");
 			else
 				Logger?.LogWarning(LogCategory.Redis, $"Deserialization failed for key '{cacheKey}'");
 

--- a/Src/CaeriusNet.csproj
+++ b/Src/CaeriusNet.csproj
@@ -12,7 +12,7 @@
 
 	<PropertyGroup>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-		<Version>9.2.3</Version>
+		<Version>9.3.0</Version>
 		<Title>CaeriusNet</Title>
 		<Authors>AriusII &amp; CaeriusNet</Authors>
 		<Description>CaeriusNet is a high-performance framework developed in C# .NET 8 + and optimized for SQL Server 2019 +. It emphasizes code quality, maintainability, and scalability by providing advanced tools for executing stored procedures and managing caching mechanisms.</Description>
@@ -45,22 +45,24 @@
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</Content>
 	</ItemGroup>
-	
+
 	<ItemGroup>
 		<!-- Microsoft Data Access -->
-		<PackageReference Include="Microsoft.Data.SqlClient" Version="6.0.1"/>
+		<PackageReference Include="Aspire.Microsoft.Data.SqlClient" Version="9.3.0"/>
+		<PackageReference Include="Aspire.StackExchange.Redis.DistributedCaching" Version="9.3.0"/>
+		<PackageReference Include="Microsoft.Data.SqlClient" Version="6.0.2"/>
 
 		<!-- Microsoft Extensions -->
 		<PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.4"/>
-		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.4"/>
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.4"/>
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.4"/>
+		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.5"/>
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.5"/>
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.5"/>
 
 		<!-- Caching -->
-		<PackageReference Include="StackExchange.Redis" Version="2.8.31"/>
+		<PackageReference Include="StackExchange.Redis" Version="2.8.37"/>
 
 		<!-- Serialization -->
-		<PackageReference Include="System.Text.Json" Version="9.0.4"/>
+		<PackageReference Include="System.Text.Json" Version="9.0.5"/>
 
 		<!-- Source Generator -->
 		<ProjectReference Include="..\SourceGenerators\CaeriusNet.Generator.csproj"/>

--- a/Src/Commands/Reads/SimpleReadSqlAsyncCommands.cs
+++ b/Src/Commands/Reads/SimpleReadSqlAsyncCommands.cs
@@ -29,7 +29,8 @@ public static class SimpleReadSqlAsyncCommands
 	/// <exception cref="CaeriusSqlException">
 	///     Thrown when the execution of the stored procedure fails due to a SQL exception.
 	/// </exception>
-	public static async Task<TResultSet?> FirstQueryAsync<TResultSet>(this ICaeriusDbContext context, StoredProcedureParameters spParameters)
+	public static async Task<TResultSet?> FirstQueryAsync<TResultSet>(this ICaeriusDbContext context,
+		StoredProcedureParameters spParameters)
 		where TResultSet : class, ISpMapper<TResultSet>
 	{
 		if (CacheUtility.TryRetrieveFromCache(spParameters, out TResultSet? cachedResult) && cachedResult != null)
@@ -73,7 +74,8 @@ public static class SimpleReadSqlAsyncCommands
 	/// <exception cref="CaeriusSqlException">
 	///     Thrown when the execution of the stored procedure fails due to a SQL exception.
 	/// </exception>
-	public static async Task<ReadOnlyCollection<TResultSet>> QueryAsReadOnlyCollectionAsync<TResultSet>(this ICaeriusDbContext context, StoredProcedureParameters spParameters)
+	public static async Task<ReadOnlyCollection<TResultSet>> QueryAsReadOnlyCollectionAsync<TResultSet>(
+		this ICaeriusDbContext context, StoredProcedureParameters spParameters)
 		where TResultSet : class, ISpMapper<TResultSet>
 	{
 		if (CacheUtility.TryRetrieveFromCache(spParameters, out ReadOnlyCollection<TResultSet>? cachedResult) &&
@@ -118,10 +120,12 @@ public static class SimpleReadSqlAsyncCommands
 	/// <exception cref="CaeriusSqlException">
 	///     Thrown when the execution of the stored procedure fails due to a SQL exception.
 	/// </exception>
-	public static async Task<IEnumerable<TResultSet>> QueryAsIEnumerableAsync<TResultSet>(this ICaeriusDbContext context, StoredProcedureParameters spParameters)
+	public static async Task<IEnumerable<TResultSet>> QueryAsIEnumerableAsync<TResultSet>(
+		this ICaeriusDbContext context, StoredProcedureParameters spParameters)
 		where TResultSet : class, ISpMapper<TResultSet>
 	{
-		if (CacheUtility.TryRetrieveFromCache(spParameters, out IEnumerable<TResultSet>? cachedResult) && cachedResult != null)
+		if (CacheUtility.TryRetrieveFromCache(spParameters, out IEnumerable<TResultSet>? cachedResult) &&
+		    cachedResult != null)
 			return cachedResult;
 
 		try
@@ -164,10 +168,12 @@ public static class SimpleReadSqlAsyncCommands
 	/// <exception cref="CaeriusSqlException">
 	///     Thrown when the execution of the stored procedure fails due to a SQL exception.
 	/// </exception>
-	public static async Task<ImmutableArray<TResultSet>> QueryAsImmutableArrayAsync<TResultSet>(this ICaeriusDbContext context, StoredProcedureParameters spParameters)
+	public static async Task<ImmutableArray<TResultSet>> QueryAsImmutableArrayAsync<TResultSet>(
+		this ICaeriusDbContext context, StoredProcedureParameters spParameters)
 		where TResultSet : class, ISpMapper<TResultSet>
 	{
-		if (CacheUtility.TryRetrieveFromCache(spParameters, out ImmutableArray<TResultSet>? cachedResult) && cachedResult != null)
+		if (CacheUtility.TryRetrieveFromCache(spParameters, out ImmutableArray<TResultSet>? cachedResult) &&
+		    cachedResult != null)
 			return (ImmutableArray<TResultSet>)cachedResult;
 
 		try

--- a/Src/Commands/Writes/WriteSqlAsyncCommands.cs
+++ b/Src/Commands/Writes/WriteSqlAsyncCommands.cs
@@ -27,7 +27,8 @@ public static class WriteSqlAsyncCommands
 	///     from the database, converted to the specified type <typeparamref name="T" />.
 	///     Returns <c>default</c> if the result is <see cref="DBNull" />.
 	/// </returns>
-	public static async Task<T?> ExecuteScalarAsync<T>(this ICaeriusDbContext dbContext, StoredProcedureParameters spParameters)
+	public static async Task<T?> ExecuteScalarAsync<T>(this ICaeriusDbContext dbContext,
+		StoredProcedureParameters spParameters)
 	{
 		return await SqlCommandUtility.ExecuteCommandAsync(dbContext, spParameters, async command =>
 		{
@@ -52,9 +53,10 @@ public static class WriteSqlAsyncCommands
 	///     A task representing the asynchronous operation. The task result contains the number
 	///     of rows affected by the executed SQL command.
 	/// </returns>
-	public static async Task<int> ExecuteNonQueryAsync(this ICaeriusDbContext dbContext, StoredProcedureParameters spParameters)
+	public static async Task<int> ExecuteNonQueryAsync(this ICaeriusDbContext dbContext,
+		StoredProcedureParameters spParameters)
 	{
-		return await SqlCommandUtility.ExecuteCommandAsync(dbContext, spParameters, 
+		return await SqlCommandUtility.ExecuteCommandAsync(dbContext, spParameters,
 			async command => await command.ExecuteNonQueryAsync());
 	}
 

--- a/Src/Extensions/CaeriusServiceCollectionExtension.cs
+++ b/Src/Extensions/CaeriusServiceCollectionExtension.cs
@@ -1,4 +1,5 @@
 ﻿using CaeriusNet.Logging;
+using Microsoft.Extensions.Hosting;
 
 namespace CaeriusNet.Extensions;
 
@@ -20,12 +21,31 @@ public static class CaeriusServiceCollectionExtension
 	}
 
 	/// <summary>
+	///     Registers the Caerius ORM with Aspire SQL Server integration.
+	/// </summary>
+	/// <param name="builder">The host application builder.</param>
+	/// <param name="connectionName">The connection string name in configuration.</param>
+	/// <returns>The host application builder instance for method chaining.</returns>
+	public static IHostApplicationBuilder AddCaeriusNetWithAspire(this IHostApplicationBuilder builder,
+		string connectionName = "sqlserver")
+	{
+		// Add SQL Server client using Aspire
+		builder.AddSqlServerClient(connectionName);
+
+		// Register Caerius DB context using the connection string from configuration
+		builder.Services.AddSingleton<ICaeriusDbContext, CaeriusDbContext>(_ => new CaeriusDbContext(connectionName));
+
+		return builder;
+	}
+
+	/// <summary>
 	///     Registers the Caerius Redis cache in the service collection (service provider).
 	/// </summary>
 	/// <param name="services">The IServiceCollection to which the Caerius Redis cache dependencies will be registered.</param>
 	/// <param name="redisConnectionString">The Redis connection string used to establish the connection to the Redis server.</param>
 	/// <returns>The IServiceCollection instance for method chaining.</returns>
-	public static IServiceCollection AddCaeriusRedisCache(this IServiceCollection services, string redisConnectionString)
+	public static IServiceCollection AddCaeriusRedisCache(this IServiceCollection services,
+		string redisConnectionString)
 	{
 		if (!string.IsNullOrWhiteSpace(redisConnectionString))
 			RedisCacheManager.Initialize(redisConnectionString);
@@ -34,7 +54,25 @@ public static class CaeriusServiceCollectionExtension
 	}
 
 	/// <summary>
-	///	 Registers and configures the Caerius console logging service in the service collection.
+	///     Registers the Caerius Redis distributed cache using .NET Aspire integration.
+	/// </summary>
+	/// <param name="builder">The host application builder.</param>
+	/// <param name="connectionName">The Redis connection name in configuration.</param>
+	/// <returns>The host application builder instance for method chaining.</returns>
+	public static IHostApplicationBuilder AddCaeriusAspireRedisDistribuedCache(this IHostApplicationBuilder builder,
+		string connectionName = "cache")
+	{
+		// Add Redis distributed cache using Aspire
+		builder.AddRedisDistributedCache(connectionName);
+
+		// Initialize AspireRedisCacheManager with IDistributedCache from DI
+		builder.Services.AddSingleton<AspireRedisCacheManager>();
+
+		return builder;
+	}
+
+	/// <summary>
+	///     Registers and configures the Caerius console logging service in the service collection.
 	/// </summary>
 	/// <param name="services">The IServiceCollection to which the console logger will be registered.</param>
 	/// <returns>The IServiceCollection instance for method chaining.</returns>

--- a/Src/Utilities/CacheType.cs
+++ b/Src/Utilities/CacheType.cs
@@ -7,5 +7,6 @@ public enum CacheType : byte
 {
 	Frozen,
 	InMemory,
-	Redis
+	Redis,
+	AspireRedis
 }

--- a/Src/Utilities/CacheUtility.cs
+++ b/Src/Utilities/CacheUtility.cs
@@ -21,6 +21,8 @@ internal static class CacheUtility
 			InMemory => InMemoryCacheManager.TryGet(spParameters.CacheKey, out result),
 			Frozen => FrozenCacheManager.TryGet(spParameters.CacheKey, out result),
 			Redis => RedisCacheManager.IsInitialized() && RedisCacheManager.TryGet(spParameters.CacheKey, out result),
+			AspireRedis => AspireRedisCacheManager.IsInitialized() &&
+			               AspireRedisCacheManager.TryGet(spParameters.CacheKey, out result),
 			_ => false
 		};
 	}
@@ -49,6 +51,10 @@ internal static class CacheUtility
 			case Redis:
 				if (RedisCacheManager.IsInitialized())
 					RedisCacheManager.Store(spParameters.CacheKey, result, spParameters.CacheExpiration);
+				break;
+			case AspireRedis:
+				if (AspireRedisCacheManager.IsInitialized())
+					AspireRedisCacheManager.Store(spParameters.CacheKey, result, spParameters.CacheExpiration);
 				break;
 			case null:
 				break;

--- a/Src/Utilities/SqlCommandUtility.cs
+++ b/Src/Utilities/SqlCommandUtility.cs
@@ -23,7 +23,8 @@ internal static class SqlCommandUtility
 	///     Returns an instance of <typeparamref name="TResultSet" /> if the query returns a result, or
 	///     <see langword="null" /> if no result is found.
 	/// </returns>
-	internal static async Task<TResultSet?> ScalarQueryAsync<TResultSet>(StoredProcedureParameters spParameters, IDbConnection connection)
+	internal static async Task<TResultSet?> ScalarQueryAsync<TResultSet>(StoredProcedureParameters spParameters,
+		IDbConnection connection)
 		where TResultSet : class, ISpMapper<TResultSet>
 	{
 		await using var command = await ExecuteSqlCommand(spParameters, connection);
@@ -53,7 +54,8 @@ internal static class SqlCommandUtility
 	///     An asynchronous enumerable of <typeparamref name="TResultSet" /> instances, where each instance maps a
 	///     corresponding row in the result set.
 	/// </returns>
-	internal static async IAsyncEnumerable<TResultSet> StreamQueryAsync<TResultSet>(StoredProcedureParameters spParameters, IDbConnection connection)
+	internal static async IAsyncEnumerable<TResultSet> StreamQueryAsync<TResultSet>(
+		StoredProcedureParameters spParameters, IDbConnection connection)
 		where TResultSet : class, ISpMapper<TResultSet>
 	{
 		await using var command = await ExecuteSqlCommand(spParameters, connection);
@@ -80,7 +82,8 @@ internal static class SqlCommandUtility
 	///     A <see cref="ReadOnlyCollection{T}" /> containing instances of <typeparamref name="TResultSet" /> populated
 	///     from the query result.
 	/// </returns>
-	internal static async Task<ReadOnlyCollection<TResultSet>> ResultSetAsReadOnlyCollectionAsync<TResultSet>(StoredProcedureParameters spParameters, IDbConnection connection)
+	internal static async Task<ReadOnlyCollection<TResultSet>> ResultSetAsReadOnlyCollectionAsync<TResultSet>(
+		StoredProcedureParameters spParameters, IDbConnection connection)
 		where TResultSet : class, ISpMapper<TResultSet>
 	{
 		var results = new List<TResultSet>(spParameters.Capacity);
@@ -105,7 +108,8 @@ internal static class SqlCommandUtility
 	///     Returns an immutable array of <typeparamref name="TResultSet" /> instances representing the result set of the
 	///     query.
 	/// </returns>
-	internal static async Task<ImmutableArray<TResultSet>> ResultSetAsImmutableArrayAsync<TResultSet>(StoredProcedureParameters spParameters, IDbConnection connection)
+	internal static async Task<ImmutableArray<TResultSet>> ResultSetAsImmutableArrayAsync<TResultSet>(
+		StoredProcedureParameters spParameters, IDbConnection connection)
 		where TResultSet : class, ISpMapper<TResultSet>
 	{
 		var builder = ImmutableArray.CreateBuilder<TResultSet>(spParameters.Capacity);
@@ -163,7 +167,8 @@ internal static class SqlCommandUtility
 	///     Thrown when the execution of the stored procedure fails due to an underlying SQL
 	///     exception.
 	/// </exception>
-	internal static async Task<T> ExecuteCommandAsync<T>(ICaeriusDbContext dbContext, StoredProcedureParameters spParameters, Func<SqlCommand, Task<T>> execute)
+	internal static async Task<T> ExecuteCommandAsync<T>(ICaeriusDbContext dbContext,
+		StoredProcedureParameters spParameters, Func<SqlCommand, Task<T>> execute)
 	{
 		try
 		{
@@ -281,7 +286,8 @@ internal static class SqlCommandUtility
 	///     A list of <see cref="IEnumerable{T}" /> objects, where each enumerable represents a result set mapped according
 	///     to the corresponding mapping function provided in <paramref name="mappers" />.
 	/// </returns>
-	internal static async Task<List<IEnumerable<object>>> ExecuteMultipleIEnumerableResultSetsAsync(StoredProcedureParameters spParameters, IDbConnection connection,
+	internal static async Task<List<IEnumerable<object>>> ExecuteMultipleIEnumerableResultSetsAsync(
+		StoredProcedureParameters spParameters, IDbConnection connection,
 		params Func<SqlDataReader, object>[] mappers)
 	{
 		if (mappers.Length == 0)


### PR DESCRIPTION
This commit introduces the "CaeriusNet.Exemples" project, showcasing usage patterns with example repositories, models, and configurations. Additionally, it adds support for Redis caching via .NET Aspire integration, including cache utilities, service extensions, and new dependencies. Various refactors and library upgrades are also included.