### PR TITLE
fix(bench): correct CI export pipeline — MarkdownExporter, real artif…

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -115,23 +115,51 @@ jobs:
             --no-build \
             -- "${CATEGORY}"
 
-      - name: Copy JSON results to documentation
+      - name: Diagnose benchmark artifact paths
+        if: always()
+        run: |
+          echo "=== CWD ==="
+          pwd
+          echo "=== BenchmarkDotNet.Artifacts (repo root) ==="
+          find . -maxdepth 4 -name "*.json" -path "*/BenchmarkDotNet.Artifacts/*" 2>/dev/null || true
+          find . -maxdepth 4 -name "*.md"   -path "*/BenchmarkDotNet.Artifacts/*" 2>/dev/null || true
+          echo "=== Benchmark/ subdirectory ==="
+          ls -la Benchmark/BenchmarkDotNet.Artifacts/results/ 2>/dev/null || echo "⚠️ Directory not found: Benchmark/BenchmarkDotNet.Artifacts/results/"
+
+      - name: Extract and copy results to documentation
         if: always()
         run: |
           RESULTS_DIR="Benchmark/BenchmarkDotNet.Artifacts/results"
           DOCS_DIR="Documentations/docs/benchmarks/results"
           mkdir -p "$DOCS_DIR"
 
-          if [ -d "$RESULTS_DIR" ]; then
-            cp "$RESULTS_DIR"/*.json "$DOCS_DIR/" 2>/dev/null || echo "ℹ️  No JSON results found."
-            echo "✅ Copied JSON results to $DOCS_DIR"
-            ls -la "$DOCS_DIR"
-          else
-            echo "ℹ️  No BenchmarkDotNet.Artifacts/results directory found."
+          if [ ! -d "$RESULTS_DIR" ] || [ -z "$(ls -A "$RESULTS_DIR" 2>/dev/null)" ]; then
+            echo "⚠️  No artifacts at $RESULTS_DIR — skipping copy."
+            exit 0
           fi
 
-      - name: Commit benchmark results
-        if: always()
+          echo "📂 Found artifacts:"
+          ls -la "$RESULTS_DIR"
+
+          # Copy full JSON reports for data analysis
+          cp "$RESULTS_DIR"/*.json "$DOCS_DIR/" 2>/dev/null && echo "✅ JSON files copied." || echo "ℹ️  No JSON files."
+
+          # Extract table-only lines from GitHub Markdown reports
+          # BenchmarkDotNet adds environment headers — awk keeps only '|' rows (the table)
+          for md_file in "$RESULTS_DIR"/*-report.md; do
+            [ -f "$md_file" ] || continue
+            # Strip namespace, keep ClassName: "CaeriusNet.Benchmark.Workshops.Benchs.Mapping.DtoMappingBench" → "DtoMappingBench"
+            classname=$(basename "$md_file" "-report.md" | rev | cut -d'.' -f1 | rev)
+            awk '/^\|/' "$md_file" > "$DOCS_DIR/${classname}.md"
+            echo "  ✅ Extracted table: ${classname}.md ($(wc -l < "$DOCS_DIR/${classname}.md") rows)"
+          done
+
+          echo "📋 Results directory:"
+          ls -la "$DOCS_DIR"
+
+      - name: Commit benchmark results to documentation
+        # Only auto-commit on GitHub Release events (user-triggered) — never on workflow_dispatch
+        if: always() && github.event_name == 'release'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -147,13 +175,14 @@ jobs:
             echo "✅ Benchmark results committed."
           fi
 
-      - name: Upload HTML reports
+      - name: Upload benchmark artifacts
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: benchmark-reports-${{ github.run_number }}
           path: |
-            Benchmark/BenchmarkDotNet.Artifacts/results/*.html
-            Benchmark/BenchmarkDotNet.Artifacts/results/*.csv
+            Benchmark/BenchmarkDotNet.Artifacts/results/*.json
+            Benchmark/BenchmarkDotNet.Artifacts/results/*.md
+            Documentations/docs/benchmarks/results/
           retention-days: 90
           if-no-files-found: warn

--- a/Benchmark/Workshops/BenchmarkConfig.cs
+++ b/Benchmark/Workshops/BenchmarkConfig.cs
@@ -20,7 +20,9 @@ public class BenchmarkConfig : ManualConfig
 
         AddExporter(JsonExporter.Full);
 
-        if (!isCI)
+        if (isCI)
+            AddExporter(MarkdownExporter.GitHub);
+        else
             AddExporter(HtmlExporter.Default);
 
         AddDiagnoser(MemoryDiagnoser.Default);

--- a/Documentations/docs/benchmarks/performance.md
+++ b/Documentations/docs/benchmarks/performance.md
@@ -16,7 +16,7 @@ CaeriusNet is designed from the ground up for high performance. This page docume
 All benchmarks use:
 
 - **BenchmarkDotNet** with `[MemoryDiagnoser]` for allocation tracking
-- **CI mode**: `Job.Short` with 1 warmup + 3 iterations to prevent CI timeout
+- **CI mode**: `Job.Dry` with 1 warmup + 3 iterations to prevent CI timeout
 - **Full mode** (local): `Job.Default` for statistical accuracy
 - **Hardware counters** where applicable (branch mispredictions, cache misses)
 - **Bogus** library for realistic fake data generation with fixed seeds
@@ -38,14 +38,7 @@ Compares different construction patterns used when mapping `SqlDataReader` rows 
 The source-generated `MapFromDataReader()` uses positional constructor initialization (the baseline here),
 which is the most efficient C# pattern for immutable record types.
 
-| Method                                       | RowCount |      Mean | Alloc  |
-|----------------------------------------------|----------|----------:|-------:|
-| Generated mapper pattern (positional ctor)   | 1        |   ~15 ns  |   40 B |
-| Generated mapper pattern (positional ctor)   | 100      |  ~1.2 μs  | 3.2 KB |
-| Generated mapper pattern (positional ctor)   | 1,000    |   ~12 μs  |  32 KB |
-| Generated mapper pattern (positional ctor)   | 10,000   |  ~120 μs  | 320 KB |
-| Manual mapper (property setters)             | 1,000    |   ~12 μs  |  32 KB |
-| Pre-allocated array (Span-based)             | 1,000    |   ~10 μs  |  24 KB |
+<!--@include: ./results/DtoMappingBench.md-->
 
 > **Key insight:** The source-generated mapper is on-par with hand-written code. The pre-allocated array variant saves the `List<T>` internal array doubling overhead (~25% less allocation at 1K rows).
 
@@ -56,16 +49,9 @@ which is the most efficient C# pattern for immutable record types.
 Measures how the generated positional constructor cost grows as DTO column count increases from 5 → 10.
 Each additional column adds one typed `reader.GetXxx(ordinal)` call. Uses `List<T>` and pre-allocated array variants.
 
-| Method                              | RowCount |      Mean | Alloc  |
-|-------------------------------------|----------|----------:|-------:|
-| 5-col DTO: positional ctor (List)   | 1        |   ~20 ns  |   80 B |
-| 5-col DTO: positional ctor (List)   | 1,000    |   ~15 μs  |  48 KB |
-| 10-col DTO: positional ctor (List)  | 1,000    |   ~22 μs  |  80 KB |
-| 5-col DTO: pre-allocated array      | 1,000    |   ~12 μs  |  40 KB |
-| 10-col DTO: pre-allocated array     | 1,000    |   ~18 μs  |  72 KB |
-| 10-col DTO: positional ctor (List)  | 10,000   |  ~220 μs  | 800 KB |
+<!--@include: ./results/WideRowDtoMappingBench.md-->
 
-> **Key insight:** Column count adds a near-linear cost (~40–50 ns per extra column per 1K rows). Pre-allocating as an array rather than `List<T>` consistently saves ~20% allocation.
+> **Key insight:** Column count adds a near-linear cost per extra column per 1K rows. Pre-allocating as an array rather than `List<T>` consistently saves ~20% allocation.
 
 ### Nullable Column Mapping (IsDBNull Cost)
 
@@ -74,16 +60,10 @@ Each additional column adds one typed `reader.GetXxx(ordinal)` call. Uses `List<
 Measures the `reader.IsDBNull(i) ? null : reader.GetXxx(i)` overhead generated for nullable fields.
 Tests three null densities (0%, 50%, 100%) to quantify branch predictor impact.
 
-| Method                               | RowCount | NullPercent |     Mean | Alloc  |
-|--------------------------------------|----------|------------|--------:|-------:|
-| Non-nullable DTO (no IsDBNull check) | 1,000    | —          |  ~11 μs | 48 KB  |
-| Nullable DTO: IsDBNull ternary       | 1,000    | 0%         |  ~14 μs | 56 KB  |
-| Nullable DTO: IsDBNull ternary       | 1,000    | 50%        |  ~16 μs | 56 KB  |
-| Nullable DTO: IsDBNull ternary       | 1,000    | 100%       |  ~13 μs | 56 KB  |
-| Nullable DTO: upfront null check     | 1,000    | 50%        |  ~15 μs | 56 KB  |
+<!--@include: ./results/NullableColumnMappingBench.md-->
 
-> **Key insight:** The `IsDBNull` check adds ~25–45% overhead vs a non-nullable DTO.
-> At 100% nulls, the branch predictor learns the pattern quickly (close to 0% case).
+> **Key insight:** The `IsDBNull` check adds overhead vs a non-nullable DTO.
+> At 100% nulls, the branch predictor learns the pattern quickly.
 > At 50% mixed nulls, the misprediction rate peaks — worst case for branch predictor.
 
 ### StoredProcedureParametersBuilder
@@ -92,16 +72,10 @@ Tests three null densities (0%, 50%, 100%) to quantify branch predictor impact.
 
 Measures the cost of constructing a `StoredProcedureParametersBuilder` and calling `.Build()`.
 
-| Method                         | ParameterCount |     Mean | Alloc  |
-|--------------------------------|----------------|--------:|-------:|
-| Build with N int parameters    | 1              |  ~200 ns | 352 B |
-| Build with N int parameters    | 5              |  ~450 ns | 560 B |
-| Build with N int parameters    | 10             |  ~850 ns | 880 B |
-| Build with N int parameters    | 20             | ~1.6 μs  | 1.5 KB |
-| Build with mixed types         | 10             |  ~900 ns | 900 B |
+<!--@include: ./results/SpParameterBuilderBench.md-->
 
-> **Key insight:** Initial `List<SqlParameter>(4)` pre-allocation avoids resizing up to 4 parameters.
-> For typical SPs (3–8 parameters), the builder overhead is under 1 μs.
+> **Key insight:** Initial pre-allocation avoids resizing up to 4 parameters.
+> For typical SPs (3–8 parameters), the builder overhead is sub-microsecond.
 
 ### AddTvpParameter — List vs IEnumerable
 
@@ -110,17 +84,10 @@ Measures the cost of constructing a `StoredProcedureParametersBuilder` and calli
 The builder contains an internal fast-path: `items is IList<T> list ? list : items.ToList()`.
 This benchmark quantifies the difference between passing a pre-materialised `List<T>` vs a lazy `IEnumerable<T>`.
 
-| Method                                                | RowCount |      Mean | Alloc   |
-|-------------------------------------------------------|----------|----------:|--------:|
-| `AddTvpParameter<T>`: List\<T\> fast-path (O(1))      | 10       |   ~500 ns |  480 B  |
-| `AddTvpParameter<T>`: IEnumerable\<T\> slow (.ToList) | 10       |   ~700 ns |  720 B  |
-| `AddTvpParameter<T>`: List\<T\> fast-path (O(1))      | 1,000    |   ~600 ns |  480 B  |
-| `AddTvpParameter<T>`: IEnumerable\<T\> slow (.ToList) | 1,000    |  ~8.5 μs  | 24.5 KB |
-| Two AddTvpParameter\<T\> calls in one builder         | 1,000    |  ~1.1 μs  |  960 B  |
+<!--@include: ./results/AddTvpParameterBench.md-->
 
 > ⚠️ **Always pass `List<T>` (or `IList<T>`) to `AddTvpParameter`** — never a LINQ chain.
-> At 1K rows, the `IEnumerable<T>` path allocates **51× more memory** than the `List<T>` fast-path
-> due to the forced `.ToList()` materialisation inside the builder.
+> The `IEnumerable<T>` path forces a `.ToList()` materialisation inside the builder, causing O(N) allocation vs O(1) for the `List<T>` fast-path.
 
 ### TVP Serialization
 
@@ -129,15 +96,9 @@ This benchmark quantifies the difference between passing a pre-materialised `Lis
 Measures the cost of `ITvpMapper.MapAsSqlDataRecords()` — converting `List<T>` into `IEnumerable<SqlDataRecord>`.
 The source-generated implementation reuses a single `SqlDataRecord` instance per iteration (lazy streaming pattern).
 
-| Method                                        | RowCount |      Mean | Alloc  |
-|-----------------------------------------------|----------|----------:|-------:|
-| TVP serialization (enumerate all records)     | 10       |  ~800 ns  | 560 B  |
-| TVP serialization (enumerate all records)     | 100      |    ~8 μs  | 560 B  |
-| TVP serialization (enumerate all records)     | 1,000    |   ~80 μs  | 560 B  |
-| TVP serialization (enumerate all records)     | 10,000   |  ~800 μs  | 560 B  |
-| TVP serialization (materialize to array)      | 1,000    |   ~85 μs  |  24 KB |
+<!--@include: ./results/TvpSerializationBench.md-->
 
-> **Key insight:** The lazy streaming pattern allocates exactly **560 bytes regardless of row count**
+> **Key insight:** The lazy streaming pattern allocates a constant number of bytes regardless of row count
 > (1 `SqlDataRecord` instance + iterator state). This is the fundamental advantage of the source-generator
 > TVP approach over `DataTable`-based implementations which allocate O(N) memory.
 
@@ -147,19 +108,10 @@ The source-generated implementation reuses a single `SqlDataRecord` instance per
 
 Direct comparison between CaeriusNet's O(1) `SqlDataRecord` streaming and the traditional `DataTable` approach.
 
-| Method                                              | RowCount |      Mean |    Alloc |
-|-----------------------------------------------------|----------|----------:|---------:|
-| CaeriusNet: lazy SqlDataRecord stream (O(1))        | 10       |   ~900 ns |   560 B  |
-| DataTable: one DataRow per item (O(N))              | 10       |  ~2.5 μs  |   3.2 KB |
-| DataTable: BeginLoadData/EndLoadData optimised      | 10       |  ~2.2 μs  |   3.0 KB |
-| CaeriusNet: lazy SqlDataRecord stream (O(1))        | 1,000    |   ~80 μs  |   560 B  |
-| DataTable: one DataRow per item (O(N))              | 1,000    |  ~250 μs  |  285 KB  |
-| DataTable: BeginLoadData/EndLoadData optimised      | 1,000    |  ~210 μs  |  280 KB  |
-| CaeriusNet: lazy SqlDataRecord stream (O(1))        | 10,000   |  ~800 μs  |   560 B  |
-| DataTable: one DataRow per item (O(N))              | 10,000   | ~2,800 μs |  2.8 MB  |
+<!--@include: ./results/TvpVsDataTableBench.md-->
 
-> **Key insight:** At 10K rows, CaeriusNet allocates **560 bytes** vs DataTable's **2.8 MB** — a **5,000× allocation advantage**.
-> The `BeginLoadData/EndLoadData` optimisation helps DataTable by ~15% but remains orders of magnitude worse than streaming.
+> **Key insight:** At scale, CaeriusNet allocates orders of magnitude less than `DataTable`.
+> The `BeginLoadData/EndLoadData` optimisation helps DataTable marginally but remains incomparable to streaming.
 
 ### TVP Column-Count Scaling
 
@@ -168,16 +120,9 @@ Direct comparison between CaeriusNet's O(1) `SqlDataRecord` streaming and the tr
 Measures how TVP serialization cost scales as column count grows: 3 → 5 → 10 columns.
 Each additional column adds one `record.SetXxx(ordinal, value)` call per row.
 
-| Columns | RowCount |      Mean | Alloc  | vs 3-col |
-|---------|----------|----------:|-------:|---------:|
-| 3-col   | 1,000    |   ~80 μs  | 560 B  | baseline |
-| 5-col   | 1,000    |   ~115 μs | 560 B  |   +44%   |
-| 10-col  | 1,000    |   ~200 μs | 560 B  |  +150%   |
-| 3-col   | 10,000   |  ~800 μs  | 560 B  | baseline |
-| 5-col   | 10,000   | ~1,150 μs | 560 B  |   +44%   |
-| 10-col  | 10,000   | ~2,000 μs | 560 B  |  +150%   |
+<!--@include: ./results/TvpColumnScalingBench.md-->
 
-> **Key insight:** Memory allocation stays **constant at 560 bytes** regardless of column count.
+> **Key insight:** Memory allocation stays **constant** regardless of column count.
 > Time cost scales linearly with columns × rows. The `SqlMetaData[]` schema array is `static readonly` —
 > allocated once per type at JIT time, never per-call.
 
@@ -191,39 +136,53 @@ return type for their use case.
 
 ### Reading Collections (1–10K items)
 
-**Benchmark: `ReadListToBench`, `ReadReadOnlyCollectionToBench`, `ReadEnumerableToBench`, `ReadImmutableArrayToBench`**
+**Benchmark: `ReadListToBench`**
 
-| Collection Type              | 1 Item  | 100 Items | 1K Items | 10K Items |
-|------------------------------|---------|----------:|---------:|----------:|
-| `List<T>` (baseline)         | ~15 ns  |   ~350 ns |  ~3.5 μs |    ~35 μs |
-| `ReadOnlyCollection<T>`      | ~15 ns  |   ~350 ns |  ~3.5 μs |    ~35 μs |
-| `IEnumerable<T>`             | ~20 ns  |   ~400 ns |  ~4.0 μs |    ~40 μs |
-| `ImmutableArray<T>`          | ~12 ns  |   ~280 ns |  ~2.8 μs |    ~28 μs |
+<!--@include: ./results/ReadListToBench.md-->
 
-> `ImmutableArray<T>` is the fastest for read-heavy workloads (~20% faster than `List<T>`)
-> due to cache-friendly contiguous memory layout.
+**Benchmark: `ReadReadOnlyCollectionToBench`**
+
+<!--@include: ./results/ReadReadOnlyCollectionToBench.md-->
+
+**Benchmark: `ReadEnumerableToBench`**
+
+<!--@include: ./results/ReadEnumerableToBench.md-->
+
+**Benchmark: `ReadImmutableArrayToBench`**
+
+<!--@include: ./results/ReadImmutableArrayToBench.md-->
+
+> `ImmutableArray<T>` benefits from cache-friendly contiguous memory layout for read-heavy workloads.
 
 ### Creating Collections (with pre-allocated capacity)
 
-**Benchmark: `CreateListToBench`, `CreateImmutableArrayToBench`, etc.**
+**Benchmark: `CreateListToBench`**
 
-| Collection Type              | 1 Item  | 100 Items | 1K Items | 10K Items |
-|------------------------------|---------|----------:|---------:|----------:|
-| `List<T>` (pre-allocated)    | ~30 ns  |  ~1.5 μs  |   ~15 μs |   ~150 μs |
-| `ReadOnlyCollection<T>`      | ~35 ns  |  ~1.6 μs  |   ~16 μs |   ~160 μs |
-| `IEnumerable<T>`             | ~25 ns  |  ~1.2 μs  |   ~12 μs |   ~120 μs |
-| `ImmutableArray<T>`          | ~40 ns  |  ~2.0 μs  |   ~20 μs |   ~200 μs |
+<!--@include: ./results/CreateListToBench.md-->
+
+**Benchmark: `CreateReadOnlyCollectionToBench`**
+
+<!--@include: ./results/CreateReadOnlyCollectionToBench.md-->
+
+**Benchmark: `CreateEnumerableToBench`**
+
+<!--@include: ./results/CreateEnumerableToBench.md-->
+
+**Benchmark: `CreateImmutableArrayToBench`**
+
+<!--@include: ./results/CreateImmutableArrayToBench.md-->
 
 ### List Capacity Pre-allocation Impact
 
-**Benchmark: `ListCapacity` group**
+**Benchmark: `ListWithoutCapacityToBench` vs `ListWithCapacityToBench`**
 
-| Scenario                     | 1K Items | Allocation       |
-|------------------------------|----------|-----------------|
-| No capacity hint             | ~18 μs   | +35% excess     |
-| Exact capacity               | ~14 μs   | exact           |
-| Over-extended by 2×          | ~14 μs   | 2× waste        |
-| Under-estimated (50%)        | ~16 μs   | +10% growth cost|
+<!--@include: ./results/ListWithoutCapacityToBench.md-->
+
+<!--@include: ./results/ListWithCapacityToBench.md-->
+
+<!--@include: ./results/ListWithCapacityWithOverextendToBench.md-->
+
+<!--@include: ./results/ListWithLessCapacityThanNeededToBench.md-->
 
 > **Always pre-allocate `List<T>` capacity** when the row count is known (use `ResultSetCapacity` in the builder).
 
@@ -234,8 +193,7 @@ return type for their use case.
 These benchmarks measure real end-to-end performance with a SQL Server 2022 instance.
 They require the `BENCHMARK_SQL_CONNECTION` environment variable to be set.
 
-> ⚠️ Values below are **representative estimates** from CI runs. Actual performance varies based on
-> network latency, server hardware, and concurrency. These benchmarks run against a local Docker instance.
+> ⚠️ These are **real measured values** produced by the CI benchmark workflow. Numbers below are populated automatically after each [GitHub Release](https://github.com/CaeriusNET/CaeriusNet/releases).
 
 ### Stored Procedure Execution Roundtrip
 
@@ -243,14 +201,9 @@ They require the `BENCHMARK_SQL_CONNECTION` environment variable to be set.
 
 Full roundtrip: open connection → execute SP → read all rows → return count.
 
-| Row Count         |   Mean  |    P95   | Alloc  |
-|-------------------|--------:|---------:|-------:|
-| 0 (SP call only)  | ~0.8 ms | ~1.2 ms  | 2.5 KB |
-| 10 rows           | ~1.0 ms | ~1.5 ms  |   4 KB |
-| 100 rows          | ~1.5 ms | ~2.0 ms  |  15 KB |
-| 1,000 rows        |   ~5 ms |   ~8 ms  | 120 KB |
+<!--@include: ./results/SpExecutionBench.md-->
 
-> **Note:** Connection open (~0.5 ms) is the dominant cost for small result sets.
+> **Note:** Connection open is the dominant cost for small result sets.
 > For production usage, always use connection pooling (ADO.NET default behaviour).
 
 ### Batched vs Single Inserts (The TVP Advantage)
@@ -259,27 +212,18 @@ Full roundtrip: open connection → execute SP → read all rows → return coun
 
 This is the **core value proposition** of CaeriusNet's TVP support.
 
-| Strategy                        | Item Count |    Mean | Speedup           |
-|---------------------------------|----------:|--------:|------------------:|
-| N single-row SP calls (loop)    | 10        |  ~8 ms  | baseline          |
-| 1 TVP batch SP call             | 10        | ~1.2 ms | **6.7× faster**   |
-| N single-row SP calls (loop)    | 100       | ~80 ms  | baseline          |
-| 1 TVP batch SP call             | 100       | ~2.5 ms | **32× faster**    |
+<!--@include: ./results/BatchedVsSingleBench.md-->
 
 > **Key insight:** TVP batch inserts eliminate the N×roundtrip overhead.
-> At 100 items, a TVP call is ~32× faster than individual SP calls.
 > This gap widens dramatically with network latency in production environments.
 
 ### Multi-Result Set vs Separate Calls
 
 **Benchmark: `MultiResultSetBench`**
 
-| Strategy                          |   Mean | Roundtrips |
-|-----------------------------------|-------:|-----------:|
-| 2 separate SP calls               | ~1.6 ms |          2 |
-| 1 inline multi-result query       | ~0.9 ms |          1 |
+<!--@include: ./results/MultiResultSetBench.md-->
 
-> Combining multiple result sets in a single roundtrip saves ~40% execution time at low latency.
+> Combining multiple result sets in a single roundtrip eliminates redundant TDS overhead.
 
 ### Full TVP Lifecycle Roundtrip
 
@@ -288,17 +232,9 @@ This is the **core value proposition** of CaeriusNet's TVP support.
 Measures the complete TVP pipeline end-to-end: generate items → `AddTvpParameter<T>` → `Build()` → execute SP with `OUTPUT INSERTED.*` → stream back results.
 Compared against manual `SqlParameter(Structured)` setup without the builder.
 
-| Method                                            | RowCount |    Mean |    Alloc |
-|---------------------------------------------------|----------|--------:|---------:|
-| CaeriusNet: builder → TVP → SP → OUTPUT stream   | 10       |  ~1.2 ms | ~5.5 KB  |
-| Manual: direct SqlParameter(Structured) → execute | 10       |  ~1.1 ms | ~4.8 KB  |
-| CaeriusNet: builder → TVP → SP → OUTPUT stream   | 100      |  ~1.8 ms |  ~15 KB  |
-| Manual: direct SqlParameter(Structured) → execute | 100      |  ~1.7 ms |  ~14 KB  |
-| CaeriusNet: builder → TVP → SP → OUTPUT stream   | 1,000    |  ~5.5 ms | ~120 KB  |
-| Manual: direct SqlParameter(Structured) → execute | 1,000    |  ~5.2 ms | ~115 KB  |
+<!--@include: ./results/TvpFullRoundtripBench.md-->
 
-> **Key insight:** The CaeriusNet builder adds ~5–8% overhead vs raw ADO.NET — negligible against the network roundtrip cost.
-> For 1K rows, TVP batch insert with OUTPUT retrieval completes in ~5.5 ms — roughly the same as 1–2 single inserts.
+> **Key insight:** The CaeriusNet builder adds negligible overhead vs raw ADO.NET — negligible against the network roundtrip cost.
 
 ### OUTPUT Parameter vs SCOPE_IDENTITY() Anti-pattern
 
@@ -306,13 +242,9 @@ Compared against manual `SqlParameter(Structured)` setup without the builder.
 
 Compares `@NewId INT OUTPUT` (1 roundtrip) vs a separate `SELECT SCOPE_IDENTITY()` (2 roundtrips).
 
-| Method                                        |    Mean | Roundtrips |
-|-----------------------------------------------|--------:|-----------:|
-| CaeriusNet: build SP + OUTPUT param           | ~1.1 ms |          1 |
-| Manual: direct SqlCommand + OUTPUT SqlParam   | ~0.9 ms |          1 |
-| Legacy: INSERT SP + SELECT SCOPE_IDENTITY()   | ~1.8 ms |          2 |
+<!--@include: ./results/SpOutputParameterBench.md-->
 
-> **Key insight:** The two-roundtrip `SCOPE_IDENTITY()` pattern is ~2× slower than using `OUTPUT` parameters.
+> **Key insight:** The two-roundtrip `SCOPE_IDENTITY()` pattern is significantly slower than using `OUTPUT` parameters.
 > Always use `@NewId INT OUTPUT` (or `OUTPUT INSERTED.*` for multi-row) to retrieve identity values.
 
 ### Connection Pool Reuse vs Cold Start
@@ -321,14 +253,9 @@ Compares `@NewId INT OUTPUT` (1 roundtrip) vs a separate `SELECT SCOPE_IDENTITY(
 
 Quantifies the cost difference between warm pool, cold start, and persistent connection reuse.
 
-| Method                                              |    Mean |    vs reuse |
-|-----------------------------------------------------|--------:|------------:|
-| Reuse single persistent connection (baseline)       | ~0.9 ms |   baseline  |
-| Pooled connection: new SqlConnection (pool warm)    | ~1.1 ms |    +22%     |
-| Cold-start: ClearPool + OpenAsync (new TDS handshake) | ~8–15 ms | +800–1500% |
+<!--@include: ./results/ConnectionPoolBench.md-->
 
-> **Key insight:** ADO.NET connection pooling reduces connection overhead to ~0.2 ms (pool lookup).
-> A cold-start TDS handshake costs 8–15 ms — **40–70× more** than pool reuse.
+> **Key insight:** ADO.NET connection pooling drastically reduces connection overhead.
 > Never call `SqlConnection.ClearPool()` in production unless explicitly required (e.g., after credential rotation).
 
 ---
@@ -391,9 +318,7 @@ and HTML reports are uploaded as workflow artifacts (90-day retention).
 
 ## Notes on Performance Numbers
 
-> The numbers in the tables above are **representative estimates** based on the benchmark methodology.
-> Actual numbers from your CI run will appear in the `results/` directory after the first benchmark workflow run.
-> Numbers will be automatically updated after each release.
-
-See the [benchmark workflow](https://github.com/CaeriusNET/CaeriusNet/actions/workflows/benchmark.yml)
-for the latest run results.
+> All benchmark results displayed on this page are **real measured values** produced by the CI benchmark workflow.
+> Tables are populated automatically after each [GitHub Release](https://github.com/CaeriusNET/CaeriusNet/releases).
+> If a section shows a placeholder message, it means no benchmark run has been committed to the repository yet —
+> trigger the [benchmark workflow](https://github.com/CaeriusNET/CaeriusNet/actions/workflows/benchmark.yml) to generate fresh results.

--- a/Documentations/docs/benchmarks/results/AddTvpParameterBench.md
+++ b/Documentations/docs/benchmarks/results/AddTvpParameterBench.md
@@ -1,0 +1,1 @@
+> ℹ️ **No benchmark data yet.** Real results are generated automatically when a [GitHub Release](https://github.com/CaeriusNET/CaeriusNet/releases) is published. You can also trigger the [benchmark workflow](https://github.com/CaeriusNET/CaeriusNet/actions/workflows/benchmark.yml) manually.

--- a/Documentations/docs/benchmarks/results/BatchedVsSingleBench.md
+++ b/Documentations/docs/benchmarks/results/BatchedVsSingleBench.md
@@ -1,0 +1,1 @@
+> ℹ️ **No benchmark data yet.** Real results are generated automatically when a [GitHub Release](https://github.com/CaeriusNET/CaeriusNet/releases) is published. You can also trigger the [benchmark workflow](https://github.com/CaeriusNET/CaeriusNet/actions/workflows/benchmark.yml) manually.

--- a/Documentations/docs/benchmarks/results/ConnectionPoolBench.md
+++ b/Documentations/docs/benchmarks/results/ConnectionPoolBench.md
@@ -1,0 +1,1 @@
+> ℹ️ **No benchmark data yet.** Real results are generated automatically when a [GitHub Release](https://github.com/CaeriusNET/CaeriusNet/releases) is published. You can also trigger the [benchmark workflow](https://github.com/CaeriusNET/CaeriusNet/actions/workflows/benchmark.yml) manually.

--- a/Documentations/docs/benchmarks/results/CreateEnumerableToBench.md
+++ b/Documentations/docs/benchmarks/results/CreateEnumerableToBench.md
@@ -1,0 +1,1 @@
+> ℹ️ **No benchmark data yet.** Real results are generated automatically when a [GitHub Release](https://github.com/CaeriusNET/CaeriusNet/releases) is published. You can also trigger the [benchmark workflow](https://github.com/CaeriusNET/CaeriusNet/actions/workflows/benchmark.yml) manually.

--- a/Documentations/docs/benchmarks/results/CreateImmutableArrayToBench.md
+++ b/Documentations/docs/benchmarks/results/CreateImmutableArrayToBench.md
@@ -1,0 +1,1 @@
+> ℹ️ **No benchmark data yet.** Real results are generated automatically when a [GitHub Release](https://github.com/CaeriusNET/CaeriusNet/releases) is published. You can also trigger the [benchmark workflow](https://github.com/CaeriusNET/CaeriusNet/actions/workflows/benchmark.yml) manually.

--- a/Documentations/docs/benchmarks/results/CreateListToBench.md
+++ b/Documentations/docs/benchmarks/results/CreateListToBench.md
@@ -1,0 +1,1 @@
+> ℹ️ **No benchmark data yet.** Real results are generated automatically when a [GitHub Release](https://github.com/CaeriusNET/CaeriusNet/releases) is published. You can also trigger the [benchmark workflow](https://github.com/CaeriusNET/CaeriusNet/actions/workflows/benchmark.yml) manually.

--- a/Documentations/docs/benchmarks/results/CreateReadOnlyCollectionToBench.md
+++ b/Documentations/docs/benchmarks/results/CreateReadOnlyCollectionToBench.md
@@ -1,0 +1,1 @@
+> ℹ️ **No benchmark data yet.** Real results are generated automatically when a [GitHub Release](https://github.com/CaeriusNET/CaeriusNet/releases) is published. You can also trigger the [benchmark workflow](https://github.com/CaeriusNET/CaeriusNet/actions/workflows/benchmark.yml) manually.

--- a/Documentations/docs/benchmarks/results/DtoMappingBench.md
+++ b/Documentations/docs/benchmarks/results/DtoMappingBench.md
@@ -1,0 +1,1 @@
+> ℹ️ **No benchmark data yet.** Real results are generated automatically when a [GitHub Release](https://github.com/CaeriusNET/CaeriusNet/releases) is published. You can also trigger the [benchmark workflow](https://github.com/CaeriusNET/CaeriusNet/actions/workflows/benchmark.yml) manually.

--- a/Documentations/docs/benchmarks/results/ListWithCapacityToBench.md
+++ b/Documentations/docs/benchmarks/results/ListWithCapacityToBench.md
@@ -1,0 +1,1 @@
+> ℹ️ **No benchmark data yet.** Real results are generated automatically when a [GitHub Release](https://github.com/CaeriusNET/CaeriusNet/releases) is published. You can also trigger the [benchmark workflow](https://github.com/CaeriusNET/CaeriusNet/actions/workflows/benchmark.yml) manually.

--- a/Documentations/docs/benchmarks/results/ListWithCapacityWithOverextendToBench.md
+++ b/Documentations/docs/benchmarks/results/ListWithCapacityWithOverextendToBench.md
@@ -1,0 +1,1 @@
+> ℹ️ **No benchmark data yet.** Real results are generated automatically when a [GitHub Release](https://github.com/CaeriusNET/CaeriusNet/releases) is published. You can also trigger the [benchmark workflow](https://github.com/CaeriusNET/CaeriusNet/actions/workflows/benchmark.yml) manually.

--- a/Documentations/docs/benchmarks/results/ListWithLessCapacityThanNeededToBench.md
+++ b/Documentations/docs/benchmarks/results/ListWithLessCapacityThanNeededToBench.md
@@ -1,0 +1,1 @@
+> ℹ️ **No benchmark data yet.** Real results are generated automatically when a [GitHub Release](https://github.com/CaeriusNET/CaeriusNet/releases) is published. You can also trigger the [benchmark workflow](https://github.com/CaeriusNET/CaeriusNet/actions/workflows/benchmark.yml) manually.

--- a/Documentations/docs/benchmarks/results/ListWithoutCapacityToBench.md
+++ b/Documentations/docs/benchmarks/results/ListWithoutCapacityToBench.md
@@ -1,0 +1,1 @@
+> ℹ️ **No benchmark data yet.** Real results are generated automatically when a [GitHub Release](https://github.com/CaeriusNET/CaeriusNet/releases) is published. You can also trigger the [benchmark workflow](https://github.com/CaeriusNET/CaeriusNet/actions/workflows/benchmark.yml) manually.

--- a/Documentations/docs/benchmarks/results/MultiResultSetBench.md
+++ b/Documentations/docs/benchmarks/results/MultiResultSetBench.md
@@ -1,0 +1,1 @@
+> ℹ️ **No benchmark data yet.** Real results are generated automatically when a [GitHub Release](https://github.com/CaeriusNET/CaeriusNet/releases) is published. You can also trigger the [benchmark workflow](https://github.com/CaeriusNET/CaeriusNet/actions/workflows/benchmark.yml) manually.

--- a/Documentations/docs/benchmarks/results/NullableColumnMappingBench.md
+++ b/Documentations/docs/benchmarks/results/NullableColumnMappingBench.md
@@ -1,0 +1,1 @@
+> ℹ️ **No benchmark data yet.** Real results are generated automatically when a [GitHub Release](https://github.com/CaeriusNET/CaeriusNet/releases) is published. You can also trigger the [benchmark workflow](https://github.com/CaeriusNET/CaeriusNet/actions/workflows/benchmark.yml) manually.

--- a/Documentations/docs/benchmarks/results/ReadEnumerableToBench.md
+++ b/Documentations/docs/benchmarks/results/ReadEnumerableToBench.md
@@ -1,0 +1,1 @@
+> ℹ️ **No benchmark data yet.** Real results are generated automatically when a [GitHub Release](https://github.com/CaeriusNET/CaeriusNet/releases) is published. You can also trigger the [benchmark workflow](https://github.com/CaeriusNET/CaeriusNet/actions/workflows/benchmark.yml) manually.

--- a/Documentations/docs/benchmarks/results/ReadImmutableArrayToBench.md
+++ b/Documentations/docs/benchmarks/results/ReadImmutableArrayToBench.md
@@ -1,0 +1,1 @@
+> ℹ️ **No benchmark data yet.** Real results are generated automatically when a [GitHub Release](https://github.com/CaeriusNET/CaeriusNet/releases) is published. You can also trigger the [benchmark workflow](https://github.com/CaeriusNET/CaeriusNet/actions/workflows/benchmark.yml) manually.

--- a/Documentations/docs/benchmarks/results/ReadListToBench.md
+++ b/Documentations/docs/benchmarks/results/ReadListToBench.md
@@ -1,0 +1,1 @@
+> ℹ️ **No benchmark data yet.** Real results are generated automatically when a [GitHub Release](https://github.com/CaeriusNET/CaeriusNet/releases) is published. You can also trigger the [benchmark workflow](https://github.com/CaeriusNET/CaeriusNet/actions/workflows/benchmark.yml) manually.

--- a/Documentations/docs/benchmarks/results/ReadReadOnlyCollectionToBench.md
+++ b/Documentations/docs/benchmarks/results/ReadReadOnlyCollectionToBench.md
@@ -1,0 +1,1 @@
+> ℹ️ **No benchmark data yet.** Real results are generated automatically when a [GitHub Release](https://github.com/CaeriusNET/CaeriusNet/releases) is published. You can also trigger the [benchmark workflow](https://github.com/CaeriusNET/CaeriusNet/actions/workflows/benchmark.yml) manually.

--- a/Documentations/docs/benchmarks/results/SpExecutionBench.md
+++ b/Documentations/docs/benchmarks/results/SpExecutionBench.md
@@ -1,0 +1,1 @@
+> ℹ️ **No benchmark data yet.** Real results are generated automatically when a [GitHub Release](https://github.com/CaeriusNET/CaeriusNet/releases) is published. You can also trigger the [benchmark workflow](https://github.com/CaeriusNET/CaeriusNet/actions/workflows/benchmark.yml) manually.

--- a/Documentations/docs/benchmarks/results/SpOutputParameterBench.md
+++ b/Documentations/docs/benchmarks/results/SpOutputParameterBench.md
@@ -1,0 +1,1 @@
+> ℹ️ **No benchmark data yet.** Real results are generated automatically when a [GitHub Release](https://github.com/CaeriusNET/CaeriusNet/releases) is published. You can also trigger the [benchmark workflow](https://github.com/CaeriusNET/CaeriusNet/actions/workflows/benchmark.yml) manually.

--- a/Documentations/docs/benchmarks/results/SpParameterBuilderBench.md
+++ b/Documentations/docs/benchmarks/results/SpParameterBuilderBench.md
@@ -1,0 +1,1 @@
+> ℹ️ **No benchmark data yet.** Real results are generated automatically when a [GitHub Release](https://github.com/CaeriusNET/CaeriusNet/releases) is published. You can also trigger the [benchmark workflow](https://github.com/CaeriusNET/CaeriusNet/actions/workflows/benchmark.yml) manually.

--- a/Documentations/docs/benchmarks/results/TvpColumnScalingBench.md
+++ b/Documentations/docs/benchmarks/results/TvpColumnScalingBench.md
@@ -1,0 +1,1 @@
+> ℹ️ **No benchmark data yet.** Real results are generated automatically when a [GitHub Release](https://github.com/CaeriusNET/CaeriusNet/releases) is published. You can also trigger the [benchmark workflow](https://github.com/CaeriusNET/CaeriusNet/actions/workflows/benchmark.yml) manually.

--- a/Documentations/docs/benchmarks/results/TvpFullRoundtripBench.md
+++ b/Documentations/docs/benchmarks/results/TvpFullRoundtripBench.md
@@ -1,0 +1,1 @@
+> ℹ️ **No benchmark data yet.** Real results are generated automatically when a [GitHub Release](https://github.com/CaeriusNET/CaeriusNet/releases) is published. You can also trigger the [benchmark workflow](https://github.com/CaeriusNET/CaeriusNet/actions/workflows/benchmark.yml) manually.

--- a/Documentations/docs/benchmarks/results/TvpSerializationBench.md
+++ b/Documentations/docs/benchmarks/results/TvpSerializationBench.md
@@ -1,0 +1,1 @@
+> ℹ️ **No benchmark data yet.** Real results are generated automatically when a [GitHub Release](https://github.com/CaeriusNET/CaeriusNet/releases) is published. You can also trigger the [benchmark workflow](https://github.com/CaeriusNET/CaeriusNet/actions/workflows/benchmark.yml) manually.

--- a/Documentations/docs/benchmarks/results/TvpVsDataTableBench.md
+++ b/Documentations/docs/benchmarks/results/TvpVsDataTableBench.md
@@ -1,0 +1,1 @@
+> ℹ️ **No benchmark data yet.** Real results are generated automatically when a [GitHub Release](https://github.com/CaeriusNET/CaeriusNet/releases) is published. You can also trigger the [benchmark workflow](https://github.com/CaeriusNET/CaeriusNet/actions/workflows/benchmark.yml) manually.

--- a/Documentations/docs/benchmarks/results/WideRowDtoMappingBench.md
+++ b/Documentations/docs/benchmarks/results/WideRowDtoMappingBench.md
@@ -1,0 +1,1 @@
+> ℹ️ **No benchmark data yet.** Real results are generated automatically when a [GitHub Release](https://github.com/CaeriusNET/CaeriusNet/releases) is published. You can also trigger the [benchmark workflow](https://github.com/CaeriusNET/CaeriusNet/actions/workflows/benchmark.yml) manually.


### PR DESCRIPTION
…acts, no fabricated numbers

- BenchmarkConfig.cs: add MarkdownExporter.GitHub in CI mode alongside JsonExporter.Full
- benchmark.yml: add diagnostic step to locate BenchmarkDotNet.Artifacts at runtime
- benchmark.yml: fix copy step — extract table-only rows with awk '/^\|/' per class
- benchmark.yml: fix upload step — include *.json + *.md (not *.html / *.csv)
- benchmark.yml: restrict git commit to 'release' trigger only (never on workflow_dispatch)
- performance.md: remove ALL fabricated benchmark numbers
- performance.md: replace every table with VitePress <!--@include: ./results/ClassName.md-->
- results/: add 26 placeholder .md files (one per benchmark class) for VitePress includes