### PR TITLE
feat(generator): emit CAERIUS001-004 diagnostics for invalid DTO/TVP …

### DIFF
--- a/Documentations/diagnostics/CAERIUS001.md
+++ b/Documentations/diagnostics/CAERIUS001.md
@@ -1,0 +1,24 @@
+# CAERIUS001 — Type must be `sealed`
+
+**Severity**: Error
+**Category**: CaeriusNet.Generator
+
+## Cause
+
+A type decorated with `[GenerateDto]` or `[GenerateTvp]` is not declared `sealed`.
+
+## Why
+
+CaeriusNet's source generators emit per-type mappers that bypass virtual dispatch and rely on the
+exact runtime layout. Allowing inheritance would break the assumption that the generated code can
+materialise an instance using the primary constructor with no further polymorphism. Sealing the
+type also gives the JIT additional optimisation room for the hot-path mapping.
+
+## How to fix
+
+Add the `sealed` modifier:
+
+```csharp
+[GenerateDto]
+public sealed partial record FooDto(int Id, string Name);
+```

--- a/Documentations/diagnostics/CAERIUS002.md
+++ b/Documentations/diagnostics/CAERIUS002.md
@@ -1,0 +1,18 @@
+# CAERIUS002 — Type must be `partial`
+
+**Severity**: Error
+**Category**: CaeriusNet.Generator
+
+## Cause
+
+A type decorated with `[GenerateDto]` or `[GenerateTvp]` is not declared `partial`, so the
+source generator cannot extend it with the generated mapper.
+
+## How to fix
+
+Add the `partial` modifier:
+
+```csharp
+[GenerateDto]
+public sealed partial record FooDto(int Id, string Name);
+```

--- a/Documentations/diagnostics/CAERIUS003.md
+++ b/Documentations/diagnostics/CAERIUS003.md
@@ -1,0 +1,21 @@
+# CAERIUS003 — Type must declare a primary constructor
+
+**Severity**: Error
+**Category**: CaeriusNet.Generator
+
+## Cause
+
+A type decorated with `[GenerateDto]` or `[GenerateTvp]` does not declare a primary constructor.
+The generated mapper relies exclusively on the ordered parameters of the primary constructor to
+materialise instances — initialisers, properties or secondary constructors are ignored on purpose
+to keep the SQL column / object-graph mapping deterministic.
+
+## How to fix
+
+Declare a primary constructor whose parameters mirror the SQL result-set columns (DTO) or the
+TVP column ordering (TVP):
+
+```csharp
+[GenerateDto]
+public sealed partial record FooDto(int Id, string Name, DateTime CreatedAt);
+```

--- a/Documentations/diagnostics/CAERIUS004.md
+++ b/Documentations/diagnostics/CAERIUS004.md
@@ -1,0 +1,20 @@
+# CAERIUS004 — `TvpName` must not be empty
+
+**Severity**: Error
+**Category**: CaeriusNet.Generator
+
+## Cause
+
+`[GenerateTvp(TvpName = "")]` (or any whitespace-only value) is not a valid SQL Server type name.
+The generator needs a non-empty identifier to emit the `SqlParameter.TypeName` value.
+
+## How to fix
+
+Provide the fully-qualified TVP type name as configured in your SQL Server schema:
+
+```csharp
+[GenerateTvp(TvpName = "tvp_FooBar", Schema = "dbo")]
+public sealed partial record FooBarTvp(int Id, string Name);
+```
+
+The `Schema` argument is optional and defaults to `dbo`.

--- a/SourceGenerators/CaeriusNet.Generator.csproj
+++ b/SourceGenerators/CaeriusNet.Generator.csproj
@@ -11,6 +11,8 @@
         <IsRoslynComponent>true</IsRoslynComponent>
         <RootNamespace>CaeriusNet.Generator</RootNamespace>
         <Deterministic>true</Deterministic>
+        <!-- RS2008 enforces analyzer release-tracking files; not necessary for an internal source generator. -->
+        <NoWarn>$(NoWarn);RS2008</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>

--- a/SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
+++ b/SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
@@ -1,0 +1,85 @@
+﻿namespace CaeriusNet.Generator.Diagnostics;
+
+/// <summary>
+///     Centralised set of <see cref="DiagnosticDescriptor" /> instances raised by CaeriusNet source generators.
+/// </summary>
+/// <remarks>
+///     Each descriptor uses the <c>CAERIUS</c> prefix so they can be filtered, severity-overridden, or
+///     suppressed via standard <c>.editorconfig</c> rules
+///     (e.g. <c>dotnet_diagnostic.CAERIUS001.severity = warning</c>).
+/// </remarks>
+internal static class DiagnosticDescriptors
+{
+    private const string Category = "CaeriusNet.Generator";
+
+    private const string HelpLinkBase =
+        "https://github.com/CaeriusNET/CaeriusNet/blob/main/Documentations/diagnostics/";
+
+    /// <summary>
+    ///     CAERIUS001 — the decorated type is not declared <c>sealed</c>.
+    /// </summary>
+    /// <remarks>
+    ///     Message format args: <c>{0}</c> = type name, <c>{1}</c> = attribute name (e.g. <c>[GenerateDto]</c>).
+    /// </remarks>
+    internal static readonly DiagnosticDescriptor MustBeSealed = new(
+        "CAERIUS001",
+        "Type must be sealed",
+        "'{0}' is decorated with '{1}' but must be declared 'sealed' for source generation to proceed",
+        Category,
+        DiagnosticSeverity.Error,
+        true,
+        "CaeriusNet generators only target sealed types — this maximises devirtualisation, prevents inheritance hazards in the generated mapper, and matches the documented contract.",
+        HelpLinkBase + "CAERIUS001.md");
+
+    /// <summary>
+    ///     CAERIUS002 — the decorated type is not declared <c>partial</c>.
+    /// </summary>
+    /// <remarks>
+    ///     Message format args: <c>{0}</c> = type name, <c>{1}</c> = attribute name.
+    /// </remarks>
+    internal static readonly DiagnosticDescriptor MustBePartial = new(
+        "CAERIUS002",
+        "Type must be partial",
+        "'{0}' is decorated with '{1}' but must be declared 'partial' so the generator can extend it",
+        Category,
+        DiagnosticSeverity.Error,
+        true,
+        "Generated mappers are emitted as partial-class extensions; the user-declared type must be partial to receive them.",
+        HelpLinkBase + "CAERIUS002.md");
+
+    /// <summary>
+    ///     CAERIUS003 — the decorated type does not declare a primary constructor with at least one parameter.
+    /// </summary>
+    /// <remarks>
+    ///     Message format args: <c>{0}</c> = type name, <c>{1}</c> = attribute name.
+    /// </remarks>
+    internal static readonly DiagnosticDescriptor MustHavePrimaryConstructor = new(
+        "CAERIUS003",
+        "Type must declare a primary constructor with parameters",
+        "'{0}' is decorated with '{1}' but must declare a primary constructor with at least one parameter — these parameters drive the SQL column mapping",
+        Category,
+        DiagnosticSeverity.Error,
+        true,
+        "CaeriusNet uses primary-constructor parameter ordinals as the mapping contract between SQL columns and CLR properties. Without parameters there is nothing to map.",
+        HelpLinkBase + "CAERIUS003.md");
+
+    /// <summary>
+    ///     CAERIUS004 — <c>[GenerateTvp]</c> was applied with an empty/whitespace <c>TvpName</c>.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         <c>TvpName</c> is C#-required, so a missing argument is already caught by the compiler. This diagnostic
+    ///         fires only when the user explicitly assigns an empty or whitespace string.
+    ///     </para>
+    ///     <para>Message format args: <c>{0}</c> = type name.</para>
+    /// </remarks>
+    internal static readonly DiagnosticDescriptor TvpNameMustNotBeEmpty = new(
+        "CAERIUS004",
+        "[GenerateTvp] requires a non-empty TvpName",
+        "'{0}' has '[GenerateTvp]' but its 'TvpName' is empty or whitespace — set it to the SQL Server table-type name",
+        Category,
+        DiagnosticSeverity.Error,
+        true,
+        "TvpName is propagated to the generated SqlMetaData and to the SqlParameter type name. An empty value would cause a runtime failure when the parameter is sent to the server.",
+        HelpLinkBase + "CAERIUS004.md");
+}

--- a/SourceGenerators/Dto/DtoSourceGenerator.SyntaxProvider.cs
+++ b/SourceGenerators/Dto/DtoSourceGenerator.SyntaxProvider.cs
@@ -4,253 +4,196 @@ public sealed partial class DtoSourceGenerator
 {
 	/// <summary>
 	///     Analyzes type declarations to find and extract metadata from types decorated with
-	///     <see cref="GenerateDtoAttribute" />.
+	///     <see cref="GenerateDtoAttribute" />, while reporting structured diagnostics for invalid candidates.
 	/// </summary>
 	/// <param name="compilation">The current compilation containing type information.</param>
 	/// <param name="declarations">The collection of type declarations to analyze.</param>
-	/// <param name="cancellationToken">Token to monitor for cancellation requests.</param>
+	/// <param name="context">The source production context used to surface diagnostics.</param>
 	/// <returns>
-	///     An enumerable sequence of <see cref="Metadata" /> objects for valid DTO types,
-	///     or <see langword="null" /> for invalid or incomplete candidates.
+	///     An enumerable sequence of <see cref="Metadata" /> objects for valid DTO types.
 	/// </returns>
-	/// <remarks>
-	///     <para>
-	///         This method performs semantic analysis on candidate types to:
-	///     </para>
-	///     <list type="bullet">
-	///         <item>
-	///             <description>Verify the presence of <see cref="GenerateDtoAttribute" /></description>
-	///         </item>
-	///         <item>
-	///             <description>Validate type structure (sealed, partial, primary constructor)</description>
-	///         </item>
-	///         <item>
-	///             <description>Extract namespace and type information</description>
-	///         </item>
-	///         <item>
-	///             <description>Map constructor parameters to SQL types</description>
-	///         </item>
-	///     </list>
-	/// </remarks>
-	private static IEnumerable<Metadata?> GetDtoTypes(
-        Compilation compilation,
-        ImmutableArray<TypeDeclarationSyntax> declarations,
-        CancellationToken cancellationToken)
-    {
-        if (declarations.IsDefaultOrEmpty)
-            yield break;
+	private static IEnumerable<Metadata> GetDtoTypes(
+		Compilation compilation,
+		ImmutableArray<TypeDeclarationSyntax> declarations,
+		SourceProductionContext context)
+	{
+		if (declarations.IsDefaultOrEmpty)
+			yield break;
 
-        // Resolve the GenerateDto attribute symbol
-        var generateDtoAttributeSymbol =
-            compilation.GetTypeByMetadataName("CaeriusNet.Attributes.Dto.GenerateDtoAttribute");
+		// Resolve the GenerateDto attribute symbol
+		var generateDtoAttributeSymbol =
+			compilation.GetTypeByMetadataName("CaeriusNet.Attributes.Dto.GenerateDtoAttribute");
 
-        if (generateDtoAttributeSymbol is null)
-            yield break;
+		if (generateDtoAttributeSymbol is null)
+			yield break;
 
-        // Process each candidate type declaration
-        foreach (var typeDeclaration in declarations)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
+		const string attributeDisplayName = "[GenerateDto]";
 
-            // Get semantic model for this syntax tree
-            var semanticModel = compilation.GetSemanticModel(typeDeclaration.SyntaxTree);
+		// Process each candidate type declaration
+		foreach (var typeDeclaration in declarations)
+		{
+			context.CancellationToken.ThrowIfCancellationRequested();
 
-            // Resolve the type symbol
-            if (semanticModel.GetDeclaredSymbol(typeDeclaration) is not { } typeSymbol)
-                continue;
+			// Get semantic model for this syntax tree
+			var semanticModel = compilation.GetSemanticModel(typeDeclaration.SyntaxTree);
 
-            // Verify attribute presence
-            if (!HasGenerateDtoAttribute(typeSymbol, generateDtoAttributeSymbol))
-                continue;
+			// Resolve the type symbol
+			if (semanticModel.GetDeclaredSymbol(typeDeclaration) is not { } typeSymbol)
+				continue;
 
-            // Validate type structure
-            if (!ValidateDtoType(typeDeclaration))
-                continue;
+			// Verify attribute presence at the symbol level
+			if (!HasGenerateDtoAttribute(typeSymbol, generateDtoAttributeSymbol))
+				continue;
 
-            // Extract namespace information
-            var namespaceName = GetNamespace(typeSymbol);
+			// For partial types the same symbol shows up once per declaration; only handle the declaration
+			// that actually carries the attribute so diagnostics are not emitted multiple times.
+			if (!DeclarationHasAttribute(typeDeclaration, generateDtoAttributeSymbol, semanticModel))
+				continue;
 
-            // Create metadata container
-            var dtoMetadata = new Metadata(typeSymbol, typeDeclaration, namespaceName);
+			// Validate symbol-level structural requirements (handles split partial declarations correctly)
+			var validation = TypeStructureValidator.Validate(typeSymbol);
+			var location = typeDeclaration.Identifier.GetLocation();
+			var hasError = false;
 
-            // Extract and map constructor parameters
-            if (!ExtractConstructorParameters(dtoMetadata, semanticModel))
-                continue;
+			if (!validation.IsSealed)
+			{
+				context.ReportDiagnostic(Diagnostic.Create(
+					DiagnosticDescriptors.MustBeSealed, location, typeSymbol.Name, attributeDisplayName));
+				hasError = true;
+			}
 
-            yield return dtoMetadata;
-        }
-    }
+			if (!validation.IsPartial)
+			{
+				context.ReportDiagnostic(Diagnostic.Create(
+					DiagnosticDescriptors.MustBePartial, location, typeSymbol.Name, attributeDisplayName));
+				hasError = true;
+			}
+
+			if (validation.PrimaryConstructorDeclaration is null)
+			{
+				context.ReportDiagnostic(Diagnostic.Create(
+					DiagnosticDescriptors.MustHavePrimaryConstructor, location, typeSymbol.Name,
+					attributeDisplayName));
+				hasError = true;
+			}
+
+			if (hasError)
+				continue;
+
+			// Extract namespace information
+			var namespaceName = GetNamespace(typeSymbol);
+
+			// Use the declaration that actually carries the primary constructor — handles split partials
+			var declarationForExtraction = validation.PrimaryConstructorDeclaration!;
+			var dtoMetadata = new Metadata(typeSymbol, declarationForExtraction, namespaceName);
+
+			// Extract and map constructor parameters
+			if (!ExtractConstructorParameters(dtoMetadata, semanticModel))
+				continue;
+
+			yield return dtoMetadata;
+		}
+	}
 
 	/// <summary>
 	///     Determines whether a type has the <see cref="GenerateDtoAttribute" /> applied.
 	/// </summary>
-	/// <param name="typeSymbol">The type symbol to check.</param>
-	/// <param name="attributeSymbol">The resolved GenerateDto attribute symbol.</param>
-	/// <returns>
-	///     <see langword="true" /> if the type has the GenerateDto attribute; otherwise, <see langword="false" />.
-	/// </returns>
 	private static bool HasGenerateDtoAttribute(INamedTypeSymbol typeSymbol, INamedTypeSymbol attributeSymbol)
-    {
-        return typeSymbol.GetAttributes()
-            .Any(a => SymbolEqualityComparer.Default.Equals(a.AttributeClass, attributeSymbol));
-    }
+	{
+		return typeSymbol.GetAttributes()
+			.Any(a => SymbolEqualityComparer.Default.Equals(a.AttributeClass, attributeSymbol));
+	}
 
 	/// <summary>
-	///     Validates that a DTO type meets all structural requirements for code generation.
+	///     Returns <see langword="true" /> when this specific declaration syntax carries the
+	///     <see cref="GenerateDtoAttribute" />; used to avoid emitting duplicate diagnostics for partial types.
 	/// </summary>
-	/// <param name="typeDeclaration">The type declaration to validate.</param>
-	/// <returns>
-	///     <see langword="true" /> if the type is valid for generation; otherwise, <see langword="false" />.
-	/// </returns>
-	/// <remarks>
-	///     Valid DTO types must:
-	///     <list type="bullet">
-	///         <item>
-	///             <description>Be declared as <c>partial</c> (to allow code generation)</description>
-	///         </item>
-	///         <item>
-	///             <description>Be declared as <c>sealed</c> (for performance and design safety)</description>
-	///         </item>
-	///         <item>
-	///             <description>Have a primary constructor with at least one parameter</description>
-	///         </item>
-	///     </list>
-	/// </remarks>
-	private static bool ValidateDtoType(TypeDeclarationSyntax typeDeclaration)
-    {
-        var modifiers = typeDeclaration.Modifiers;
+	private static bool DeclarationHasAttribute(
+		TypeDeclarationSyntax declaration,
+		INamedTypeSymbol attributeSymbol,
+		SemanticModel semanticModel)
+	{
+		foreach (var attributeList in declaration.AttributeLists)
+			foreach (var attribute in attributeList.Attributes)
+			{
+				var resolved = semanticModel.GetSymbolInfo(attribute).Symbol?.ContainingType;
+				if (SymbolEqualityComparer.Default.Equals(resolved, attributeSymbol))
+					return true;
+			}
 
-        // Verify required modifiers: partial and sealed
-        var hasPartial = false;
-        var hasSealed = false;
-
-        foreach (var modifier in modifiers)
-        {
-            if (modifier.IsKind(SyntaxKind.PartialKeyword))
-                hasPartial = true;
-            else if (modifier.IsKind(SyntaxKind.SealedKeyword))
-                hasSealed = true;
-
-            if (hasPartial && hasSealed)
-                break;
-        }
-
-        if (!hasPartial || !hasSealed)
-            return false;
-
-        // Verify primary constructor presence
-        return typeDeclaration switch
-        {
-            ClassDeclarationSyntax classDeclaration => classDeclaration.ParameterList is not null,
-            RecordDeclarationSyntax recordDeclaration => recordDeclaration.ParameterList is not null,
-            _ => false
-        };
-    }
+		return false;
+	}
 
 	/// <summary>
 	///     Extracts the fully qualified namespace for a type.
 	/// </summary>
-	/// <param name="typeSymbol">The type symbol to analyze.</param>
-	/// <returns>
-	///     The fully qualified namespace name, or "global" if the type is in the global namespace.
-	/// </returns>
+	/// <returns>The fully qualified namespace name, or "global" if the type is in the global namespace.</returns>
 	private static string GetNamespace(INamedTypeSymbol typeSymbol)
-    {
-        return typeSymbol.ContainingNamespace is { IsGlobalNamespace: false } ns
-            ? ns.ToDisplayString()
-            : "global";
-    }
+	{
+		return typeSymbol.ContainingNamespace is { IsGlobalNamespace: false } ns
+			? ns.ToDisplayString()
+			: "global";
+	}
 
 	/// <summary>
 	///     Extracts and maps constructor parameters from the DTO's primary constructor.
 	/// </summary>
-	/// <param name="metadata">The metadata object to populate with parameter information.</param>
-	/// <param name="semanticModel">The semantic model for resolving parameter symbols.</param>
 	/// <returns>
-	///     <see langword="true" /> if at least one parameter was successfully extracted;
-	///     otherwise, <see langword="false" />.
+	///     <see langword="true" /> if at least one parameter was successfully extracted; otherwise, <see langword="false" />.
 	/// </returns>
-	/// <remarks>
-	///     <para>
-	///         This method analyzes each primary constructor parameter and creates a <see cref="ParameterMetadata" />
-	///         entry containing:
-	///     </para>
-	///     <list type="bullet">
-	///         <item>
-	///             <description>Type name and symbol information</description>
-	///         </item>
-	///         <item>
-	///             <description>Nullability analysis (considering nullable reference types and Nullable&lt;T&gt;)</description>
-	///         </item>
-	///         <item>
-	///             <description>SQL Server type mapping</description>
-	///         </item>
-	///         <item>
-	///             <description>Appropriate SqlDataReader method selection</description>
-	///         </item>
-	///         <item>
-	///             <description>Special conversion requirements (enums, DateOnly, TimeOnly, byte[])</description>
-	///         </item>
-	///         <item>
-	///             <description>Ordinal position for efficient column access</description>
-	///         </item>
-	///     </list>
-	/// </remarks>
 	private static bool ExtractConstructorParameters(Metadata metadata, SemanticModel semanticModel)
-    {
-        // Resolve the primary constructor parameter list
-        var parameterList = metadata.DeclarationSyntax switch
-        {
-            RecordDeclarationSyntax recordDeclaration => recordDeclaration.ParameterList,
-            ClassDeclarationSyntax classDeclaration => classDeclaration.ParameterList,
-            _ => null
-        };
+	{
+		var parameterList = metadata.DeclarationSyntax switch
+		{
+			RecordDeclarationSyntax recordDeclaration => recordDeclaration.ParameterList,
+			ClassDeclarationSyntax classDeclaration => classDeclaration.ParameterList,
+			_ => null
+		};
 
-        if (parameterList is null || parameterList.Parameters.Count == 0)
-            return false;
+		if (parameterList is null || parameterList.Parameters.Count == 0)
+			return false;
 
-        var parameters = parameterList.Parameters;
+		// Cross-tree primary constructors require resolving the parameter symbol on the model that owns the syntax.
+		var parameterSemanticModel = parameterList.SyntaxTree == metadata.DeclarationSyntax.SyntaxTree
+			? semanticModel
+			: semanticModel.Compilation.GetSemanticModel(parameterList.SyntaxTree);
 
-        // Process each parameter in order (ordinal position matters for SqlDataReader)
-        for (var i = 0; i < parameters.Count; i++)
-        {
-            var parameterSyntax = parameters[i];
-            var parameterSymbol = semanticModel.GetDeclaredSymbol(parameterSyntax);
+		var parameters = parameterList.Parameters;
 
-            if (parameterSymbol is null)
-                continue;
+		for (var i = 0; i < parameters.Count; i++)
+		{
+			var parameterSyntax = parameters[i];
+			var parameterSymbol = parameterSemanticModel.GetDeclaredSymbol(parameterSyntax);
 
-            var parameterType = parameterSymbol.Type;
-            var typeName = parameterType.ToDisplayString();
+			if (parameterSymbol is null)
+				continue;
 
-            // Analyze nullability considering all C# nullability features
-            var isNullable = TypeDetector.IsTypeNullable(
-                parameterType,
-                parameterSyntax.Type,
-                parameterSymbol.NullableAnnotation);
+			var parameterType = parameterSymbol.Type;
+			var typeName = parameterType.ToDisplayString();
 
-            // Determine if enum (requires cast in generated code)
-            var isEnum = TypeDetector.IsEnumType(parameterType);
+			var isNullable = TypeDetector.IsTypeNullable(
+				parameterType,
+				parameterSyntax.Type,
+				parameterSymbol.NullableAnnotation);
 
-            // Map to SQL Server type and determine appropriate reader method
-            var sqlType = TypeDetector.GetSqlType(parameterType);
-            var readerMethod = TypeDetector.GetReaderMethodForSqlType(sqlType);
-            var requiresSpecialConversion = TypeDetector.RequiresSpecialConversion(typeName) || isEnum;
+			var isEnum = TypeDetector.IsEnumType(parameterType);
+			var sqlType = TypeDetector.GetSqlType(parameterType);
+			var readerMethod = TypeDetector.GetReaderMethodForSqlType(sqlType);
+			var requiresSpecialConversion = TypeDetector.RequiresSpecialConversion(typeName) || isEnum;
 
-            // Create and add parameter metadata
-            var parameterMetadata = new ParameterMetadata(
-                parameterSymbol.Name,
-                typeName,
-                parameterType,
-                isNullable,
-                i, // Ordinal position
-                sqlType,
-                readerMethod,
-                requiresSpecialConversion);
+			var parameterMetadata = new ParameterMetadata(
+				parameterSymbol.Name,
+				typeName,
+				parameterType,
+				isNullable,
+				i,
+				sqlType,
+				readerMethod,
+				requiresSpecialConversion);
 
-            metadata.Parameters.Add(parameterMetadata);
-        }
+			metadata.Parameters.Add(parameterMetadata);
+		}
 
-        return metadata.Parameters.Count > 0;
-    }
+		return metadata.Parameters.Count > 0;
+	}
 }

--- a/SourceGenerators/Dto/DtoSourceGenerator.cs
+++ b/SourceGenerators/Dto/DtoSourceGenerator.cs
@@ -135,11 +135,8 @@ public sealed partial class DtoSourceGenerator : IIncrementalGenerator
             return;
 
         // Process each DTO candidate and generate mapper implementations
-        foreach (var dtoMetadata in GetDtoTypes(compilation, declarations, context.CancellationToken))
+        foreach (var dtoMetadata in GetDtoTypes(compilation, declarations, context))
         {
-            if (dtoMetadata is null)
-                continue;
-
             // Generate and add the source code
             var source = GenerateMapperSource(dtoMetadata);
             context.AddSource($"{dtoMetadata.RecordName}.g.cs", source);

--- a/SourceGenerators/GlobalUsings.cs
+++ b/SourceGenerators/GlobalUsings.cs
@@ -1,4 +1,5 @@
-﻿global using CaeriusNet.Generator.Helpers;
+﻿global using CaeriusNet.Generator.Diagnostics;
+global using CaeriusNet.Generator.Helpers;
 global using CaeriusNet.Generator.Models;
 global using Microsoft.CodeAnalysis;
 global using Microsoft.CodeAnalysis.CSharp;

--- a/SourceGenerators/Helpers/IsExternalInit.cs
+++ b/SourceGenerators/Helpers/IsExternalInit.cs
@@ -1,0 +1,6 @@
+﻿// netstandard2.0 polyfill so that 'init' setters and record types compile in this project.
+// Roslyn analyzers/source generators must target netstandard2.0; this internal type is recognised
+// by the C# compiler when present.
+namespace System.Runtime.CompilerServices;
+
+internal static class IsExternalInit;

--- a/SourceGenerators/Helpers/TypeStructureValidator.cs
+++ b/SourceGenerators/Helpers/TypeStructureValidator.cs
@@ -1,0 +1,73 @@
+﻿namespace CaeriusNet.Generator.Helpers;
+
+/// <summary>
+///     Symbol-level structural validator shared by the DTO and TVP generators. Walks every
+///     <see cref="ISymbol.DeclaringSyntaxReferences" /> so partial declarations split across files do not
+///     produce false-positive diagnostics.
+/// </summary>
+internal static class TypeStructureValidator
+{
+    /// <summary>
+    ///     Result of <see cref="Validate" />. <see cref="PrimaryConstructorDeclaration" /> is non-null when
+    ///     any partial declaration of the type carries a primary constructor with at least one parameter.
+    /// </summary>
+    internal readonly record struct ValidationResult(
+        bool IsSealed,
+        bool IsPartial,
+        TypeDeclarationSyntax? PrimaryConstructorDeclaration);
+
+    /// <summary>
+    ///     Validates the structural requirements expected of every CaeriusNet generator target type:
+    ///     declared <c>sealed</c>, <c>partial</c>, with a primary constructor exposing at least one parameter.
+    /// </summary>
+    /// <param name="typeSymbol">The semantic symbol resolved from a candidate syntax node.</param>
+    /// <returns>An aggregate <see cref="ValidationResult" /> usable by callers to emit diagnostics.</returns>
+    internal static ValidationResult Validate(INamedTypeSymbol typeSymbol)
+    {
+        var isSealed = typeSymbol.IsSealed;
+        var isPartial = false;
+        TypeDeclarationSyntax? primaryCtorDeclaration = null;
+
+        foreach (var declRef in typeSymbol.DeclaringSyntaxReferences)
+        {
+            if (declRef.GetSyntax() is not TypeDeclarationSyntax decl)
+                continue;
+
+            if (!isPartial)
+                foreach (var modifier in decl.Modifiers)
+                    if (modifier.IsKind(SyntaxKind.PartialKeyword))
+                    {
+                        isPartial = true;
+                        break;
+                    }
+
+            if (primaryCtorDeclaration is null)
+            {
+                var paramList = decl switch
+                {
+                    RecordDeclarationSyntax r => r.ParameterList,
+                    ClassDeclarationSyntax c => c.ParameterList,
+                    _ => null
+                };
+
+                if (paramList is { Parameters.Count: > 0 })
+                    primaryCtorDeclaration = decl;
+            }
+        }
+
+        return new ValidationResult(isSealed, isPartial, primaryCtorDeclaration);
+    }
+
+    /// <summary>
+    ///     Returns the most useful <see cref="Location" /> for diagnostics: the identifier of the first
+    ///     declaration when available, otherwise <see cref="Location.None" />.
+    /// </summary>
+    internal static Location GetIdentifierLocation(INamedTypeSymbol typeSymbol)
+    {
+        foreach (var declRef in typeSymbol.DeclaringSyntaxReferences)
+            if (declRef.GetSyntax() is TypeDeclarationSyntax decl)
+                return decl.Identifier.GetLocation();
+
+        return Location.None;
+    }
+}

--- a/SourceGenerators/Tvp/TvpSourceGenerator.SyntaxProvider.cs
+++ b/SourceGenerators/Tvp/TvpSourceGenerator.SyntaxProvider.cs
@@ -3,212 +3,193 @@
 public sealed partial class TvpSourceGenerator
 {
 	/// <summary>
-	///     Performs a fast syntactic check to determine if a node is a potential TVP generation candidate.
+	///     Result of the TVP transform: the metadata payload (when extraction succeeded enough to be useful) and
+	///     any diagnostics that should be reported to the user.
 	/// </summary>
-	/// <param name="syntaxNode">The syntax node to evaluate.</param>
-	/// <param name="cancellationToken">Token to monitor for cancellation requests.</param>
-	/// <returns>
-	///     <see langword="true" /> if the node is a sealed partial type declaration (class or record);
-	///     otherwise, <see langword="false" />.
-	/// </returns>
-	/// <remarks>
-	///     This predicate performs minimal work to quickly filter out non-candidates before semantic analysis.
-	///     It checks for:
-	///     <list type="bullet">
-	///         <item>
-	///             <description>Type declaration syntax (class or record)</description>
-	///         </item>
-	///         <item>
-	///             <description>Sealed modifier (for performance and preventing inheritance issues)</description>
-	///         </item>
-	///         <item>
-	///             <description>Partial modifier (required for code generation)</description>
-	///         </item>
-	///     </list>
-	/// </remarks>
-	private static bool IsTvpCandidate(SyntaxNode syntaxNode, CancellationToken cancellationToken)
-    {
-        if (syntaxNode is not TypeDeclarationSyntax typeDeclaration)
-            return false;
-
-        var modifiers = typeDeclaration.Modifiers;
-
-        // Must be both partial and sealed
-        var hasPartial = false;
-        var hasSealed = false;
-
-        foreach (var modifier in modifiers)
-        {
-            if (modifier.IsKind(SyntaxKind.PartialKeyword))
-                hasPartial = true;
-            else if (modifier.IsKind(SyntaxKind.SealedKeyword))
-                hasSealed = true;
-
-            if (hasPartial && hasSealed)
-                return true;
-        }
-
-        return false;
-    }
+	internal sealed class TvpExtractionResult
+	{
+		internal Metadata? Metadata { get; init; }
+		internal ImmutableArray<Diagnostic> Diagnostics { get; init; } = ImmutableArray<Diagnostic>.Empty;
+		internal bool HasErrors { get; init; }
+	}
 
 	/// <summary>
-	///     Extracts comprehensive metadata from a type decorated with <see cref="GenerateTvpAttribute" />.
+	///     Fast syntactic filter: any class or record declaration is a candidate. The attribute name match performed
+	///     by <see cref="SyntaxValueProvider.ForAttributeWithMetadataName" /> is the real filter; this predicate
+	///     deliberately does NOT enforce <c>sealed</c>/<c>partial</c> so violations can be diagnosed downstream.
 	/// </summary>
-	/// <param name="context">The generator attribute syntax context containing semantic information.</param>
-	/// <param name="cancellationToken">Token to monitor for cancellation requests.</param>
-	/// <returns>
-	///     A <see cref="Metadata" /> object containing all information needed for code generation,
-	///     or <see langword="null" /> if the type is invalid or extraction fails.
-	/// </returns>
-	/// <remarks>
-	///     This transform method performs semantic analysis to extract:
-	///     <list type="bullet">
-	///         <item>
-	///             <description>Type and namespace information</description>
-	///         </item>
-	///         <item>
-	///             <description>TVP name and schema from the attribute</description>
-	///         </item>
-	///         <item>
-	///             <description>Constructor parameters with type mapping</description>
-	///         </item>
-	///     </list>
-	/// </remarks>
-	private static Metadata? ExtractTvpMetadata(GeneratorAttributeSyntaxContext context,
-        CancellationToken cancellationToken)
-    {
-        cancellationToken.ThrowIfCancellationRequested();
+	private static bool IsTvpCandidate(SyntaxNode syntaxNode, CancellationToken cancellationToken)
+	{
+		_ = cancellationToken;
+		return syntaxNode is ClassDeclarationSyntax or RecordDeclarationSyntax;
+	}
 
-        if (context.TargetSymbol is not INamedTypeSymbol classSymbol)
-            return null;
+	/// <summary>
+	///     Extracts comprehensive metadata from a type decorated with <see cref="GenerateTvpAttribute" />, building
+	///     diagnostics for every structural violation encountered.
+	/// </summary>
+	private static TvpExtractionResult ExtractTvpMetadata(GeneratorAttributeSyntaxContext context,
+		CancellationToken cancellationToken)
+	{
+		cancellationToken.ThrowIfCancellationRequested();
 
-        if (context.TargetNode is not TypeDeclarationSyntax declarationSyntax)
-            return null;
+		if (context.TargetSymbol is not INamedTypeSymbol classSymbol ||
+		    context.TargetNode is not TypeDeclarationSyntax declarationSyntax)
+			return new TvpExtractionResult();
 
-        // Determine the namespace (empty string for global namespace)
-        var namespaceName = classSymbol.ContainingNamespace.IsGlobalNamespace
-            ? string.Empty
-            : classSymbol.ContainingNamespace.ToDisplayString();
+		const string attributeDisplayName = "[GenerateTvp]";
+		var diagnostics = ImmutableArray.CreateBuilder<Diagnostic>();
+		var location = declarationSyntax.Identifier.GetLocation();
+		var hasError = false;
 
-        // Create the metadata container
-        var metadata = new Metadata(classSymbol, declarationSyntax, namespaceName);
+		var validation = TypeStructureValidator.Validate(classSymbol);
 
-        // Extract TVP configuration from the attribute
-        ExtractTvpNameFromAttribute(context, metadata);
+		if (!validation.IsSealed)
+		{
+			diagnostics.Add(Diagnostic.Create(
+				DiagnosticDescriptors.MustBeSealed, location, classSymbol.Name, attributeDisplayName));
+			hasError = true;
+		}
 
-        // Extract and map constructor parameters
-        ExtractConstructorParameters(classSymbol, metadata);
+		if (!validation.IsPartial)
+		{
+			diagnostics.Add(Diagnostic.Create(
+				DiagnosticDescriptors.MustBePartial, location, classSymbol.Name, attributeDisplayName));
+			hasError = true;
+		}
 
-        return metadata;
-    }
+		if (validation.PrimaryConstructorDeclaration is null)
+		{
+			diagnostics.Add(Diagnostic.Create(
+				DiagnosticDescriptors.MustHavePrimaryConstructor, location, classSymbol.Name, attributeDisplayName));
+			hasError = true;
+		}
+
+		// Determine the namespace (empty string for global namespace)
+		var namespaceName = classSymbol.ContainingNamespace.IsGlobalNamespace
+			? string.Empty
+			: classSymbol.ContainingNamespace.ToDisplayString();
+
+		// Always create the metadata so callers can yield diagnostics even if generation is impossible.
+		var metadata = new Metadata(classSymbol, validation.PrimaryConstructorDeclaration ?? declarationSyntax,
+			namespaceName);
+
+		// Extract TVP configuration from the attribute and validate non-empty TvpName
+		var tvpNameDiag = ExtractTvpNameFromAttribute(context, metadata, location);
+		if (tvpNameDiag is not null)
+		{
+			diagnostics.Add(tvpNameDiag);
+			hasError = true;
+		}
+
+		// Only attempt parameter extraction when there is a primary constructor; without it, downstream
+		// code generation cannot produce a useful mapper.
+		if (validation.PrimaryConstructorDeclaration is not null)
+			ExtractPrimaryConstructorParameters(validation.PrimaryConstructorDeclaration, classSymbol, metadata);
+
+		return new TvpExtractionResult
+		{
+			Metadata = metadata,
+			Diagnostics = diagnostics.ToImmutable(),
+			HasErrors = hasError
+		};
+	}
 
 	/// <summary>
 	///     Extracts the TVP name and schema configuration from the <see cref="GenerateTvpAttribute" />.
 	/// </summary>
-	/// <param name="context">The generator context containing attribute data.</param>
-	/// <param name="metadata">The metadata object to populate with TVP configuration.</param>
-	/// <remarks>
-	///     This method reads the named arguments from the attribute:
-	///     <list type="bullet">
-	///         <item>
-	///             <description><c>TvpName</c> (required): The name of the SQL Server TVP type</description>
-	///         </item>
-	///         <item>
-	///             <description><c>Schema</c> (optional): The database schema, defaults to "dbo"</description>
-	///         </item>
-	///     </list>
-	/// </remarks>
-	private static void ExtractTvpNameFromAttribute(GeneratorAttributeSyntaxContext context, Metadata metadata)
-    {
-        // Locate the GenerateTvp attribute in the context
-        var generateTvpAttribute = context.Attributes.FirstOrDefault(attr =>
-            attr.AttributeClass?.Name == "GenerateTvpAttribute");
+	/// <returns>
+	///     A diagnostic when <c>TvpName</c> is explicitly empty/whitespace; otherwise <see langword="null" />.
+	/// </returns>
+	private static Diagnostic? ExtractTvpNameFromAttribute(
+		GeneratorAttributeSyntaxContext context,
+		Metadata metadata,
+		Location fallbackLocation)
+	{
+		var generateTvpAttribute = context.Attributes.FirstOrDefault(static attr =>
+			attr.AttributeClass?.Name == "GenerateTvpAttribute");
 
-        if (generateTvpAttribute is null)
-            return;
+		if (generateTvpAttribute is null)
+			return null;
 
-        // Extract TvpName (required property)
-        var tvpNameArg =
-            generateTvpAttribute.NamedArguments.FirstOrDefault(na => na.Key == "TvpName");
+		// Schema (optional, defaults to "dbo")
+		var schemaArg = generateTvpAttribute.NamedArguments.FirstOrDefault(static na => na.Key == "Schema");
+		metadata.TvpSchema = schemaArg.Value.Value is string schema && !string.IsNullOrWhiteSpace(schema)
+			? schema
+			: "dbo";
 
-        if (tvpNameArg.Value.Value is string tvpName && !string.IsNullOrWhiteSpace(tvpName))
-            metadata.TvpName = tvpName;
+		// TvpName (required by C# but possibly empty/whitespace at the call-site)
+		var tvpNameArg = generateTvpAttribute.NamedArguments.FirstOrDefault(static na => na.Key == "TvpName");
+		var tvpNameValue = tvpNameArg.Value.Value as string;
 
-        // Extract Schema (optional, defaults to "dbo")
-        var schemaArg =
-            generateTvpAttribute.NamedArguments.FirstOrDefault(na => na.Key == "Schema");
+		if (!string.IsNullOrWhiteSpace(tvpNameValue))
+		{
+			metadata.TvpName = tvpNameValue;
+			return null;
+		}
 
-        metadata.TvpSchema = schemaArg.Value.Value is string schema && !string.IsNullOrWhiteSpace(schema)
-            ? schema
-            : "dbo";
-    }
+		// Locate the attribute syntax for a more precise error location, if available.
+		var attributeLocation = generateTvpAttribute.ApplicationSyntaxReference?.GetSyntax().GetLocation()
+		                        ?? fallbackLocation;
+
+		return Diagnostic.Create(
+			DiagnosticDescriptors.TvpNameMustNotBeEmpty,
+			attributeLocation,
+			metadata.RecordName);
+	}
 
 	/// <summary>
-	///     Extracts and maps constructor parameters to their SQL Server equivalents.
+	///     Extracts the primary constructor parameters of a TVP target. This intentionally mirrors the DTO contract
+	///     (primary constructor only) rather than picking the longest constructor — keeps the mapping deterministic
+	///     and consistent with the SQL column ordering expected by SqlMetaData.
 	/// </summary>
-	/// <param name="classSymbol">The type symbol to analyze.</param>
-	/// <param name="metadata">The metadata object to populate with parameter information.</param>
-	/// <remarks>
-	///     <para>
-	///         This method identifies the primary constructor (or the constructor with the most parameters)
-	///         and creates a <see cref="ParameterMetadata" /> entry for each parameter, including:
-	///     </para>
-	///     <list type="bullet">
-	///         <item>
-	///             <description>Type mapping to SQL Server types</description>
-	///         </item>
-	///         <item>
-	///             <description>Nullability analysis</description>
-	///         </item>
-	///         <item>
-	///             <description>Appropriate SqlDataReader method selection</description>
-	///         </item>
-	///         <item>
-	///             <description>Special conversion requirements (e.g., DateOnly, TimeOnly)</description>
-	///         </item>
-	///     </list>
-	/// </remarks>
-	private static void ExtractConstructorParameters(INamedTypeSymbol classSymbol, Metadata metadata)
-    {
-        // Find the primary constructor or the one with the most parameters
-        var constructor = classSymbol.Constructors
-            .Where(static c => !c.IsStatic)
-            .OrderByDescending(static c => c.Parameters.Length)
-            .FirstOrDefault();
+	private static void ExtractPrimaryConstructorParameters(
+		TypeDeclarationSyntax primaryCtorDeclaration,
+		INamedTypeSymbol classSymbol,
+		Metadata metadata)
+	{
+		var parameterList = primaryCtorDeclaration switch
+		{
+			RecordDeclarationSyntax r => r.ParameterList,
+			ClassDeclarationSyntax c => c.ParameterList,
+			_ => null
+		};
 
-        if (constructor is null)
-            return;
+		if (parameterList is null || parameterList.Parameters.Count == 0)
+			return;
 
-        var parameters = constructor.Parameters;
+		// Prefer the symbol-based primary constructor (records expose it; classes with a primary ctor expose one
+		// instance constructor matching the parameter count).
+		var primaryConstructor = classSymbol.Constructors.FirstOrDefault(c =>
+			!c.IsStatic && c.Parameters.Length == parameterList.Parameters.Count);
 
-        for (var i = 0; i < parameters.Length; i++)
-        {
-            var parameter = parameters[i];
-            var parameterType = parameter.Type;
+		if (primaryConstructor is null)
+			return;
 
-            // Analyze nullability using the type detector
-            var isNullable = TypeDetector.IsTypeNullable(
-                parameterType,
-                nullableAnnotation: parameter.NullableAnnotation);
+		var parameters = primaryConstructor.Parameters;
+		for (var i = 0; i < parameters.Length; i++)
+		{
+			var parameter = parameters[i];
+			var parameterType = parameter.Type;
 
-            // Map to SQL type and determine reader method
-            var sqlType = TypeDetector.GetSqlType(parameterType);
-            var readerMethod = TypeDetector.GetReaderMethodForSqlType(sqlType);
-            var typeDisplayString = parameterType.ToDisplayString();
-            var requiresSpecialConversion = TypeDetector.RequiresSpecialConversion(typeDisplayString);
+			var isNullable = TypeDetector.IsTypeNullable(
+				parameterType,
+				nullableAnnotation: parameter.NullableAnnotation);
 
-            // Create parameter metadata
-            var parameterMetadata = new ParameterMetadata(
-                parameter.Name,
-                typeDisplayString,
-                parameterType,
-                isNullable,
-                i,
-                sqlType,
-                readerMethod,
-                requiresSpecialConversion);
+			var sqlType = TypeDetector.GetSqlType(parameterType);
+			var readerMethod = TypeDetector.GetReaderMethodForSqlType(sqlType);
+			var typeDisplayString = parameterType.ToDisplayString();
+			var requiresSpecialConversion = TypeDetector.RequiresSpecialConversion(typeDisplayString);
 
-            metadata.Parameters.Add(parameterMetadata);
-        }
-    }
+			metadata.Parameters.Add(new ParameterMetadata(
+				parameter.Name,
+				typeDisplayString,
+				parameterType,
+				isNullable,
+				i,
+				sqlType,
+				readerMethod,
+				requiresSpecialConversion));
+		}
+	}
 }

--- a/SourceGenerators/Tvp/TvpSourceGenerator.cs
+++ b/SourceGenerators/Tvp/TvpSourceGenerator.cs
@@ -59,14 +59,16 @@ public sealed partial class TvpSourceGenerator : IIncrementalGenerator
             .ForAttributeWithMetadataName(
                 "CaeriusNet.Attributes.Tvp.GenerateTvpAttribute",
                 static (syntaxNode, cancellationToken) => IsTvpCandidate(syntaxNode, cancellationToken),
-                static (context, cancellationToken) => ExtractTvpMetadata(context, cancellationToken))
-            .Where(static metadata => metadata is not null);
+                static (context, cancellationToken) => ExtractTvpMetadata(context, cancellationToken));
 
-        // Register the code generation action
-        context.RegisterSourceOutput(tvpCandidates, static (context, tvpMetadata) =>
+        // Register the code generation action: emit any diagnostics first, then generate when valid.
+        context.RegisterSourceOutput(tvpCandidates, static (context, extraction) =>
         {
-            if (tvpMetadata is not null)
-                GenerateTvpMapper(context, tvpMetadata);
+            foreach (var diagnostic in extraction.Diagnostics)
+                context.ReportDiagnostic(diagnostic);
+
+            if (!extraction.HasErrors && extraction.Metadata is not null && extraction.Metadata.Parameters.Count > 0)
+                GenerateTvpMapper(context, extraction.Metadata);
         });
     }
 }

--- a/Tests/CaeriusNet.Generator.Tests/Diagnostics/DiagnosticTests.cs
+++ b/Tests/CaeriusNet.Generator.Tests/Diagnostics/DiagnosticTests.cs
@@ -1,0 +1,187 @@
+namespace CaeriusNet.Generator.Tests.Diagnostics;
+
+/// <summary>
+///     Validates that the source generators surface user-friendly compile-time diagnostics
+///     (CAERIUS001-004) instead of silently skipping invalid candidates.
+/// </summary>
+public sealed class DiagnosticTests
+{
+	private static IEnumerable<Diagnostic> RunDto(string source) =>
+		SourceGeneratorTestHelper.RunGenerator<DtoSourceGenerator>(source).Diagnostics;
+
+	private static IEnumerable<Diagnostic> RunTvp(string source) =>
+		SourceGeneratorTestHelper.RunGenerator<TvpSourceGenerator>(source).Diagnostics;
+
+	private static GeneratorDriverRunResult RunDtoFull(string source) =>
+		SourceGeneratorTestHelper.RunGenerator<DtoSourceGenerator>(source);
+
+	private static GeneratorDriverRunResult RunTvpFull(string source) =>
+		SourceGeneratorTestHelper.RunGenerator<TvpSourceGenerator>(source);
+
+	[Fact]
+	public void Dto_NonSealed_Reports_CAERIUS001()
+	{
+		const string source = """
+		                      using CaeriusNet.Attributes.Dto;
+		                      namespace TestNs;
+		                      [GenerateDto]
+		                      public partial record FooDto(int Id);
+		                      """;
+
+		var diagnostics = RunDto(source).ToList();
+
+		Assert.Contains(diagnostics, d => d.Id == "CAERIUS001" && d.Severity == DiagnosticSeverity.Error);
+		Assert.Empty(RunDtoFull(source).GeneratedTrees);
+	}
+
+	[Fact]
+	public void Dto_NonPartial_Reports_CAERIUS002()
+	{
+		const string source = """
+		                      using CaeriusNet.Attributes.Dto;
+		                      namespace TestNs;
+		                      [GenerateDto]
+		                      public sealed record FooDto(int Id);
+		                      """;
+
+		var diagnostics = RunDto(source).ToList();
+
+		Assert.Contains(diagnostics, d => d.Id == "CAERIUS002" && d.Severity == DiagnosticSeverity.Error);
+	}
+
+	[Fact]
+	public void Dto_NoPrimaryConstructor_Reports_CAERIUS003()
+	{
+		const string source = """
+		                      using CaeriusNet.Attributes.Dto;
+		                      namespace TestNs;
+		                      [GenerateDto]
+		                      public sealed partial class FooDto
+		                      {
+		                          public int Id { get; set; }
+		                      }
+		                      """;
+
+		var diagnostics = RunDto(source).ToList();
+
+		Assert.Contains(diagnostics, d => d.Id == "CAERIUS003" && d.Severity == DiagnosticSeverity.Error);
+		Assert.Empty(RunDtoFull(source).GeneratedTrees);
+	}
+
+	[Fact]
+	public void Dto_Valid_Sealed_Partial_Record_Reports_NoCaeriusDiagnostic()
+	{
+		const string source = """
+		                      using CaeriusNet.Attributes.Dto;
+		                      namespace TestNs;
+		                      [GenerateDto]
+		                      public sealed partial record FooDto(int Id, string Name);
+		                      """;
+
+		var diagnostics = RunDto(source).ToList();
+
+		Assert.DoesNotContain(diagnostics, d => d.Id.StartsWith("CAERIUS", StringComparison.Ordinal));
+		Assert.NotEmpty(RunDtoFull(source).GeneratedTrees);
+	}
+
+	[Fact]
+	public void Dto_SplitPartial_AttributeOnOneSide_Reports_NoCaeriusDiagnostic()
+	{
+		// The attribute is carried by the declaration that does not include the primary constructor;
+		// the validator must walk all DeclaringSyntaxReferences to confirm the type is well-formed.
+		const string source = """
+		                      using CaeriusNet.Attributes.Dto;
+		                      namespace TestNs;
+		                      [GenerateDto]
+		                      public sealed partial record FooDto;
+		                      public sealed partial record FooDto(int Id, string Name);
+		                      """;
+
+		var diagnostics = RunDto(source).ToList();
+
+		Assert.DoesNotContain(diagnostics, d => d.Id.StartsWith("CAERIUS", StringComparison.Ordinal));
+		Assert.NotEmpty(RunDtoFull(source).GeneratedTrees);
+	}
+
+	[Fact]
+	public void Tvp_NonSealed_Reports_CAERIUS001()
+	{
+		const string source = """
+		                      using CaeriusNet.Attributes.Tvp;
+		                      namespace TestNs;
+		                      [GenerateTvp(TvpName = "tvp_Foo")]
+		                      public partial record FooTvp(int Id);
+		                      """;
+
+		var diagnostics = RunTvp(source).ToList();
+
+		Assert.Contains(diagnostics, d => d.Id == "CAERIUS001" && d.Severity == DiagnosticSeverity.Error);
+		Assert.Empty(RunTvpFull(source).GeneratedTrees);
+	}
+
+	[Fact]
+	public void Tvp_NonPartial_Reports_CAERIUS002()
+	{
+		const string source = """
+		                      using CaeriusNet.Attributes.Tvp;
+		                      namespace TestNs;
+		                      [GenerateTvp(TvpName = "tvp_Foo")]
+		                      public sealed record FooTvp(int Id);
+		                      """;
+
+		var diagnostics = RunTvp(source).ToList();
+
+		Assert.Contains(diagnostics, d => d.Id == "CAERIUS002" && d.Severity == DiagnosticSeverity.Error);
+	}
+
+	[Fact]
+	public void Tvp_NoPrimaryConstructor_Reports_CAERIUS003()
+	{
+		const string source = """
+		                      using CaeriusNet.Attributes.Tvp;
+		                      namespace TestNs;
+		                      [GenerateTvp(TvpName = "tvp_Foo")]
+		                      public sealed partial class FooTvp
+		                      {
+		                          public int Id { get; set; }
+		                      }
+		                      """;
+
+		var diagnostics = RunTvp(source).ToList();
+
+		Assert.Contains(diagnostics, d => d.Id == "CAERIUS003" && d.Severity == DiagnosticSeverity.Error);
+		Assert.Empty(RunTvpFull(source).GeneratedTrees);
+	}
+
+	[Fact]
+	public void Tvp_EmptyTvpName_Reports_CAERIUS004()
+	{
+		const string source = """
+		                      using CaeriusNet.Attributes.Tvp;
+		                      namespace TestNs;
+		                      [GenerateTvp(TvpName = "   ")]
+		                      public sealed partial record FooTvp(int Id);
+		                      """;
+
+		var diagnostics = RunTvp(source).ToList();
+
+		Assert.Contains(diagnostics, d => d.Id == "CAERIUS004" && d.Severity == DiagnosticSeverity.Error);
+		Assert.Empty(RunTvpFull(source).GeneratedTrees);
+	}
+
+	[Fact]
+	public void Tvp_Valid_Reports_NoCaeriusDiagnostic()
+	{
+		const string source = """
+		                      using CaeriusNet.Attributes.Tvp;
+		                      namespace TestNs;
+		                      [GenerateTvp(TvpName = "tvp_Foo")]
+		                      public sealed partial record FooTvp(int Id, string Name);
+		                      """;
+
+		var diagnostics = RunTvp(source).ToList();
+
+		Assert.DoesNotContain(diagnostics, d => d.Id.StartsWith("CAERIUS", StringComparison.Ordinal));
+		Assert.NotEmpty(RunTvpFull(source).GeneratedTrees);
+	}
+}


### PR DESCRIPTION
…candidates

DTO and TVP source generators previously skipped malformed candidates silently. They now surface compile-time errors with help-link URLs:

- CAERIUS001 type must be sealed
- CAERIUS002 type must be partial
- CAERIUS003 type must declare a primary constructor
- CAERIUS004 [GenerateTvp] TvpName must not be empty/whitespace

Validation is performed at the symbol level (walks every DeclaringSyntaxReference) so split partial declarations no longer trigger false positives. The TVP pipeline now extracts parameters from the primary constructor only, matching the DTO contract and the SQL column ordering it produces. Adds a netstandard2.0 IsExternalInit polyfill and a TypeStructureValidator helper shared by both generators.

Tests: 10 new diagnostic tests (positive + valid + split-partial). Suite: 102 + 89 = 191 green.