### PR TITLE
docs: add CHANGELOG; tighten cancellation + isolation-level integrati…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,74 @@
+# Changelog
+
+All notable changes to **CaeriusNet** are documented in this file.
+
+The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+> Source-generator artefacts (`CaeriusNet.Generator`) ship together with the runtime
+> package and follow the same version cadence.
+
+## [Unreleased]
+
+### Added
+- **Integration tests** (`Tests/CaeriusNet.IntegrationTests`) — real SQL Server 2022 backed
+  by `Testcontainers.MsSql`, exercising the public surface end-to-end (stored procedures,
+  TVPs, transactions, isolation-level pass-through). Gated behind a dedicated GitHub
+  Actions workflow (`workflow_dispatch` + targeted PR paths) so the default CI stays
+  Docker-free.
+- **Devcontainer** (`.devcontainer/`) based on the official .NET 10 Bookworm image with
+  `docker-outside-of-docker`, GitHub CLI and Node features. The post-create hook restores
+  the solution and pre-pulls the SQL Server image to shorten the first run.
+
+### Changed
+- `ci.yml` now filters out the integration project (`FullyQualifiedName!~CaeriusNet.IntegrationTests`)
+  to keep PR feedback fast.
+
+## [10.3.0] — Audit follow-up wave
+
+### Added
+- **Cache invalidation API** (`ICaeriusNetCache`) — explicit, multi-provider façade that
+  invalidates by key or pattern across in-memory / Redis / frozen layers without leaking
+  the underlying `IMemoryCache` / `IDistributedCache` instances. Configurable in-memory
+  size limit on `WithInMemoryCache(...)`.
+- **Transactions API** (`ICaeriusNetTransaction`) — `await using` scope obtained via
+  `ICaeriusNetDbContext.BeginTransactionAsync(IsolationLevel)`. Provides `CommitAsync`,
+  `RollbackAsync`, dispose-time implicit rollback, command-slot serialisation,
+  `Poison()` on SQL failure, and explicit rejection of nested
+  `BeginTransactionAsync` (`NotSupportedException`). Cache writes are bypassed for any
+  command issued inside a transaction (read-your-writes guarantee).
+- **Source-generator diagnostics** `CAERIUS001`-`CAERIUS004` — actionable errors when a
+  `[GenerateDto]` / `[GenerateTvp]` candidate violates the partial-record contract,
+  declares unsupported member shapes, or omits the required TVP type name.
+
+### Changed
+- `WithSqlServer(...)` now validates the connection string at registration time so
+  misconfiguration fails fast at `Build()`.
+- `Microsoft.Data.SqlClient` upgraded to `7.0.0`.
+
+## [10.2.0] — Benchmark hardening
+
+### Added
+- Professional **BenchmarkDotNet** suite with heavy-load profiles, GitHub-Markdown +
+  JSON exporters, and a VitePress documentation pipeline that publishes the latest
+  performance reports.
+
+## [10.1.0] — Source generator GA
+
+### Added
+- `[GenerateDto]` / `[GenerateTvp]` source generators emit `ISpMapper<T>` /
+  `ITvpMapper<T>` implementations for partial records, eliminating reflection-based
+  mapping from the hot path.
+
+## [10.0.0] — .NET 10 / C# 14 baseline
+
+### Changed
+- Target framework moved to `net10.0`, language version to `latest` (C# 14).
+- All read APIs return `ValueTask<T>`; all write APIs return `ValueTask<int>` /
+  `ValueTask<T?>`. Synchronous overloads removed.
+
+[Unreleased]: https://github.com/CaeriusNET/CaeriusNet/compare/v10.3.0...HEAD
+[10.3.0]: https://github.com/CaeriusNET/CaeriusNet/releases/tag/v10.3.0
+[10.2.0]: https://github.com/CaeriusNET/CaeriusNet/releases/tag/v10.2.0
+[10.1.0]: https://github.com/CaeriusNET/CaeriusNet/releases/tag/v10.1.0
+[10.0.0]: https://github.com/CaeriusNET/CaeriusNet/releases/tag/v10.0.0

--- a/Tests/CaeriusNet.IntegrationTests/Sql/schema.sql
+++ b/Tests/CaeriusNet.IntegrationTests/Sql/schema.sql
@@ -10,6 +10,7 @@ IF OBJECT_ID(N'dbo.usp_ListWidgets', N'P') IS NOT NULL DROP PROCEDURE dbo.usp_Li
 IF OBJECT_ID(N'dbo.usp_CountWidgets', N'P') IS NOT NULL DROP PROCEDURE dbo.usp_CountWidgets;
 IF OBJECT_ID(N'dbo.usp_DeleteWidget', N'P') IS NOT NULL DROP PROCEDURE dbo.usp_DeleteWidget;
 IF OBJECT_ID(N'dbo.usp_LongRunning', N'P') IS NOT NULL DROP PROCEDURE dbo.usp_LongRunning;
+IF OBJECT_ID(N'dbo.usp_GetSessionIsolationLevel', N'P') IS NOT NULL DROP PROCEDURE dbo.usp_GetSessionIsolationLevel;
 IF OBJECT_ID(N'dbo.Widgets', N'U') IS NOT NULL DROP TABLE dbo.Widgets;
 
 CREATE TABLE dbo.Widgets
@@ -91,5 +92,15 @@ BEGIN
     DECLARE @delay CHAR(8) = CONVERT(CHAR(8), DATEADD(SECOND, @Seconds, 0), 108);
     WAITFOR DELAY @delay;
     SELECT 1;
+END;
+GO
+
+CREATE PROCEDURE dbo.usp_GetSessionIsolationLevel
+AS
+BEGIN
+    SET NOCOUNT ON;
+    SELECT CAST(transaction_isolation_level AS SMALLINT)
+    FROM sys.dm_exec_sessions
+    WHERE session_id = @@SPID;
 END;
 GO

--- a/Tests/CaeriusNet.IntegrationTests/Tests/StoredProcedureTests.cs
+++ b/Tests/CaeriusNet.IntegrationTests/Tests/StoredProcedureTests.cs
@@ -97,10 +97,17 @@ public sealed class StoredProcedureTests(SqlServerFixture fixture) : IAsyncLifet
 			.AddParameter("@Seconds", 10, SqlDbType.Int)
 			.Build();
 
-		// Microsoft.Data.SqlClient surfaces cancellation as either OperationCanceledException
-		// (preferred) or a wrapped SqlException; both are valid contracts to validate here.
-		await Assert.ThrowsAnyAsync<Exception>(async () =>
+		// Microsoft.Data.SqlClient may surface a cancelled query either as a raw
+		// OperationCanceledException (token observed before/during ADO.NET I/O) or wrap a
+		// SqlException, which CaeriusNet then re-wraps as CaeriusNetSqlException. Both are
+		// valid contracts for "the request was cancelled".
+		var exception = await Record.ExceptionAsync(async () =>
 			await db.ExecuteScalarAsync<int>(p, cts.Token));
+
+		Assert.NotNull(exception);
+		Assert.True(
+			exception is OperationCanceledException or CaeriusNetSqlException,
+			$"Expected OperationCanceledException or CaeriusNetSqlException, got {exception!.GetType().FullName}: {exception.Message}");
 	}
 
 	[Fact]

--- a/Tests/CaeriusNet.IntegrationTests/Tests/TransactionTests.cs
+++ b/Tests/CaeriusNet.IntegrationTests/Tests/TransactionTests.cs
@@ -109,6 +109,28 @@ public sealed class TransactionTests(SqlServerFixture fixture) : IAsyncLifetime
 		await tx.RollbackAsync();
 	}
 
+	[Theory]
+	[InlineData(IsolationLevel.ReadCommitted, 2)]
+	[InlineData(IsolationLevel.RepeatableRead, 3)]
+	[InlineData(IsolationLevel.Serializable, 4)]
+	public async Task BeginTransactionAsync_Honors_Requested_IsolationLevel(IsolationLevel requested, short expectedSqlServerLevel)
+	{
+		using var scope = fixture.CreateScope();
+		var db = scope.ServiceProvider.GetRequiredService<ICaeriusNetDbContext>();
+
+		await using var tx = await db.BeginTransactionAsync(requested);
+
+		// Ask the server itself which isolation level the current session is running under.
+		// sys.dm_exec_sessions.transaction_isolation_level: 1=ReadUncommitted, 2=ReadCommitted,
+		// 3=RepeatableRead, 4=Serializable, 5=Snapshot.
+		var probe = new StoredProcedureParametersBuilder("dbo", "usp_GetSessionIsolationLevel").Build();
+		var actual = await tx.ExecuteScalarAsync<short>(probe);
+
+		Assert.Equal(expectedSqlServerLevel, actual);
+
+		await tx.RollbackAsync();
+	}
+
 	private async Task<T> ScalarAsync<T>(string sql)
 	{
 		await using var connection = new SqlConnection(fixture.ConnectionString);


### PR DESCRIPTION
…on tests

- CHANGELOG.md: document v10.3 wave (cache invalidation + transactions + diagnostics) and the unreleased devcontainer / integration test additions, with stub history back to 10.0.
- StoredProcedureTests: cancellation test now asserts the contract (OperationCanceledException OR CaeriusNetSqlException) rather than ThrowsAnyAsync<Exception>; the library only wraps SqlException, so OCE is the natural surface when the token wins the race.
- TransactionTests: added a Theory verifying the requested IsolationLevel is honored by SQL Server itself, queried via sys.dm_exec_sessions inside the open transaction. Public ICaeriusNetTransaction does not expose the underlying SqlTransaction by design, so we ask the server.
- schema.sql: new dbo.usp_GetSessionIsolationLevel probe used by the isolation-level Theory.