### PR TITLE
Update dependencies and improve documentation formatting

### DIFF
--- a/Benchmark/CaeriusNet.Benchmark.csproj
+++ b/Benchmark/CaeriusNet.Benchmark.csproj
@@ -12,7 +12,7 @@
     <ItemGroup>
         <PackageReference Include="BenchmarkDotNet" Version="0.15.8"/>
         <PackageReference Include="Bogus" Version="35.6.5"/>
-        <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.1"/>
+        <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.2"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/Exemples/Aspire/CaeriusNet.Exemples.Aspire.AppHost/CaeriusNet.Exemples.Aspire.AppHost.csproj
+++ b/Exemples/Aspire/CaeriusNet.Exemples.Aspire.AppHost/CaeriusNet.Exemples.Aspire.AppHost.csproj
@@ -11,10 +11,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Aspire.Hosting.AppHost" Version="13.3.2"/>
-        <PackageReference Include="Aspire.Hosting.Redis" Version="13.3.2"/>
-        <PackageReference Include="Aspire.Hosting.SqlServer" Version="13.3.2"/>
-        <PackageReference Include="Aspire.StackExchange.Redis" Version="13.3.2"/>
+        <PackageReference Include="Aspire.Hosting.AppHost" Version="13.4.6"/>
+        <PackageReference Include="Aspire.Hosting.Redis" Version="13.4.6"/>
+        <PackageReference Include="Aspire.Hosting.SqlServer" Version="13.4.6"/>
+        <PackageReference Include="Aspire.StackExchange.Redis" Version="13.4.6"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/Exemples/Aspire/CaeriusNet.Exemples.Aspire.Console/CaeriusNet.Exemples.Aspire.Console.csproj
+++ b/Exemples/Aspire/CaeriusNet.Exemples.Aspire.Console/CaeriusNet.Exemples.Aspire.Console.csproj
@@ -13,8 +13,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.8"/>
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9"/>
         <!-- Ensure the app process loads Microsoft.Data.SqlClient (align with library) -->
-        <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.1"/>
+        <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.2"/>
     </ItemGroup>
 </Project>

--- a/Exemples/Aspire/CaeriusNet.Exemples.Aspire.ServiceDefaults/CaeriusNet.Exemples.Aspire.ServiceDefaults.csproj
+++ b/Exemples/Aspire/CaeriusNet.Exemples.Aspire.ServiceDefaults/CaeriusNet.Exemples.Aspire.ServiceDefaults.csproj
@@ -10,12 +10,12 @@
     <ItemGroup>
         <FrameworkReference Include="Microsoft.AspNetCore.App"/>
 
-        <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.6.0"/>
-        <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="10.6.0"/>
-        <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3"/>
-        <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3"/>
-        <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2"/>
-        <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1"/>
+        <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.7.0"/>
+        <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="10.7.0"/>
+        <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.16.0"/>
+        <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.16.0"/>
+        <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.16.0"/>
+        <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.16.0"/>
         <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1"/>
     </ItemGroup>
 

--- a/Exemples/Libs/CaeriusNet.Exemples.Libs.Commons/CaeriusNet.Exemples.Libs.Commons.csproj
+++ b/Exemples/Libs/CaeriusNet.Exemples.Libs.Commons/CaeriusNet.Exemples.Libs.Commons.csproj
@@ -14,7 +14,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.8"/>
+        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.9"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/Src/CaeriusNet.csproj
+++ b/Src/CaeriusNet.csproj
@@ -102,16 +102,16 @@
 
     <ItemGroup>
         <!-- Microsoft Data Access -->
-        <PackageReference Include="Aspire.Microsoft.Data.SqlClient" Version="13.3.2"/>
-        <PackageReference Include="Aspire.StackExchange.Redis.DistributedCaching" Version="13.3.2"/>
-        <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.1"/>
+        <PackageReference Include="Aspire.Microsoft.Data.SqlClient" Version="13.4.6"/>
+        <PackageReference Include="Aspire.StackExchange.Redis.DistributedCaching" Version="13.4.6"/>
+        <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.2"/>
 
         <!-- Microsoft Extensions -->
-        <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.8"/>
-        <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.8"/>
-        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.8"/>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8"/>
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8"/>
+        <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.9"/>
+        <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.9"/>
+        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9"/>
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9"/>
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9"/>
 
         <!-- Source Generator -->
         <ProjectReference Include="..\SourceGenerators\CaeriusNet.Generator.csproj"

--- a/Src/README.md
+++ b/Src/README.md
@@ -17,7 +17,8 @@ passes Table-Valued Parameters, and caches results — all in a single package, 
 dotnet add package CaeriusNet
 ```
 
-AutoContracts is included in `CaeriusNet`. Set the MSBuild properties when you want build-time SQL Server contract discovery; there is no additional install step.
+AutoContracts is included in `CaeriusNet`. Set the MSBuild properties when you want build-time SQL Server contract
+discovery; there is no additional install step.
 
 ## Prerequisites
 
@@ -114,7 +115,8 @@ int rows = await dbContext.ExecuteNonQueryAsync(sp, ct);
 
 ## AutoContracts
 
-AutoContracts validates stored procedure contracts from SQL Server metadata during normal builds. Add `CaeriusNet` to the project that owns your data-access code, then use MSBuild properties to pull or verify the manifest.
+AutoContracts validates stored procedure contracts from SQL Server metadata during normal builds. Add `CaeriusNet` to
+the project that owns your data-access code, then use MSBuild properties to pull or verify the manifest.
 
 ```xml
 <PropertyGroup>
@@ -127,7 +129,8 @@ AutoContracts validates stored procedure contracts from SQL Server metadata duri
 dotnet build
 ```
 
-`Pull` creates or refreshes `caerius.contracts.json`. Commit that file with your code. In CI, switch to `Verify` so the build fails if SQL Server metadata drifts from the committed manifest.
+`Pull` creates or refreshes `caerius.contracts.json`. Commit that file with your code. In CI, switch to `Verify` so the
+build fails if SQL Server metadata drifts from the committed manifest.
 
 ## Caching
 

--- a/Tests/CaeriusNet.Analyzer.Tests/CaeriusNet.Analyzer.Tests.csproj
+++ b/Tests/CaeriusNet.Analyzer.Tests/CaeriusNet.Analyzer.Tests.csproj
@@ -16,7 +16,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0"/>
         <PackageReference Include="xunit" Version="2.9.3"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Tests/CaeriusNet.Generator.Tests/CaeriusNet.Generator.Tests.csproj
+++ b/Tests/CaeriusNet.Generator.Tests/CaeriusNet.Generator.Tests.csproj
@@ -15,17 +15,17 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0"/>
         <PackageReference Include="xunit" Version="2.9.3"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="10.0.0">
+        <PackageReference Include="coverlet.collector" Version="10.0.1">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.msbuild" Version="10.0.0">
+        <PackageReference Include="coverlet.msbuild" Version="10.0.1">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/Tests/CaeriusNet.IntegrationTests/CaeriusNet.IntegrationTests.csproj
+++ b/Tests/CaeriusNet.IntegrationTests/CaeriusNet.IntegrationTests.csproj
@@ -14,14 +14,14 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0"/>
         <PackageReference Include="xunit" Version="2.9.3"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.1"/>
-        <PackageReference Include="Testcontainers.MsSql" Version="4.11.0"/>
+        <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.2"/>
+        <PackageReference Include="Testcontainers.MsSql" Version="4.12.0"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/Tests/CaeriusNet.Packaging.Tests/AutoContractsPackagingTests.cs
+++ b/Tests/CaeriusNet.Packaging.Tests/AutoContractsPackagingTests.cs
@@ -26,7 +26,8 @@ public sealed class AutoContractsPackagingTests
         Assert.NotNull(archive.GetEntry("tools/net10.0/any/CaeriusNet.SqlServer.Contracts.deps.json"));
         Assert.NotNull(archive.GetEntry("tools/net10.0/any/CaeriusNet.SqlServer.Contracts.runtimeconfig.json"));
         Assert.NotNull(archive.GetEntry("tools/net10.0/any/Microsoft.Data.SqlClient.dll"));
-        Assert.NotNull(archive.GetEntry("tools/net10.0/any/Microsoft.Extensions.Configuration.EnvironmentVariables.dll"));
+        Assert.NotNull(
+            archive.GetEntry("tools/net10.0/any/Microsoft.Extensions.Configuration.EnvironmentVariables.dll"));
         Assert.NotNull(archive.GetEntry("tools/net10.0/any/Microsoft.Extensions.Configuration.Json.dll"));
 
         var nuspec = archive.Entries.Single(entry => entry.FullName.EndsWith(".nuspec", StringComparison.Ordinal));

--- a/Tests/CaeriusNet.Packaging.Tests/CaeriusNet.Packaging.Tests.csproj
+++ b/Tests/CaeriusNet.Packaging.Tests/CaeriusNet.Packaging.Tests.csproj
@@ -14,7 +14,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0"/>
         <PackageReference Include="xunit" Version="2.9.3"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Tests/CaeriusNet.Tests/CaeriusNet.Tests.csproj
+++ b/Tests/CaeriusNet.Tests/CaeriusNet.Tests.csproj
@@ -14,21 +14,21 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0"/>
         <PackageReference Include="xunit" Version="2.9.3"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="10.0.0">
+        <PackageReference Include="coverlet.collector" Version="10.0.1">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.msbuild" Version="10.0.0">
+        <PackageReference Include="coverlet.msbuild" Version="10.0.1">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.1"/>
+        <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.2"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/Tools/CaeriusNet.SqlServer.Contracts/CaeriusNet.SqlServer.Contracts.csproj
+++ b/Tools/CaeriusNet.SqlServer.Contracts/CaeriusNet.SqlServer.Contracts.csproj
@@ -13,9 +13,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.1"/>
-        <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.8"/>
-        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.8"/>
+        <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.2"/>
+        <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.9"/>
+        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9"/>
     </ItemGroup>
 
 </Project>

--- a/Tools/CaeriusNet.SqlServer.Contracts/README.md
+++ b/Tools/CaeriusNet.SqlServer.Contracts/README.md
@@ -1,8 +1,10 @@
 # AutoContracts tool
 
-This project builds the internal AutoContracts SQL Server discovery tool that ships inside the main `CaeriusNet` NuGet package.
+This project builds the internal AutoContracts SQL Server discovery tool that ships inside the main `CaeriusNet` NuGet
+package.
 
-It is not a standalone public package. Consumers install only `CaeriusNet`; the package imports the MSBuild targets and invokes this tool from its embedded `tools/net10.0/any` assets during normal `dotnet build` commands.
+It is not a standalone public package. Consumers install only `CaeriusNet`; the package imports the MSBuild targets and
+invokes this tool from its embedded `tools/net10.0/any` assets during normal `dotnet build` commands.
 
 ## Consumer usage
 
@@ -54,17 +56,18 @@ If SQL Server metadata no longer matches `caerius.contracts.json`, the build fai
 
 ## Configuration
 
-| Property | Default | Purpose |
-|---|---|---|
-| `CaeriusContractsMode` | `Off` | Enables `Pull`, `Verify`, or disables AutoContracts. |
-| `CaeriusContractsOutput` | `$(ProjectDir)caerius.contracts.json` | Manifest path. |
-| `CaeriusContractsConnectionName` | `DefaultConnection` | Named connection string from .NET configuration. |
-| `CaeriusContractsConnectionStringEnv` | Empty | Environment variable that contains the SQL Server connection string. |
-| `CaeriusContractsConnectionString` | Empty | Inline connection string. Prefer configuration or secrets instead. |
-| `CaeriusContractsConfigurationBasePath` | `$(MSBuildProjectDirectory)` | Directory used to load configuration files. |
-| `CaeriusContractsConfigurationEnvironment` | Empty | Environment suffix for `appsettings.{environment}.json`. |
-| `CaeriusContractsUserSecretsId` | Project `UserSecretsId` | User secrets ID override. |
+| Property                                   | Default                               | Purpose                                                              |
+|--------------------------------------------|---------------------------------------|----------------------------------------------------------------------|
+| `CaeriusContractsMode`                     | `Off`                                 | Enables `Pull`, `Verify`, or disables AutoContracts.                 |
+| `CaeriusContractsOutput`                   | `$(ProjectDir)caerius.contracts.json` | Manifest path.                                                       |
+| `CaeriusContractsConnectionName`           | `DefaultConnection`                   | Named connection string from .NET configuration.                     |
+| `CaeriusContractsConnectionStringEnv`      | Empty                                 | Environment variable that contains the SQL Server connection string. |
+| `CaeriusContractsConnectionString`         | Empty                                 | Inline connection string. Prefer configuration or secrets instead.   |
+| `CaeriusContractsConfigurationBasePath`    | `$(MSBuildProjectDirectory)`          | Directory used to load configuration files.                          |
+| `CaeriusContractsConfigurationEnvironment` | Empty                                 | Environment suffix for `appsettings.{environment}.json`.             |
+| `CaeriusContractsUserSecretsId`            | Project `UserSecretsId`               | User secrets ID override.                                            |
 
 ## Read-only behavior
 
-AutoContracts reads SQL Server metadata only. It does not create, update, or delete database objects, and it does not inspect table data.
+AutoContracts reads SQL Server metadata only. It does not create, update, or delete database objects, and it does not
+inspect table data.


### PR DESCRIPTION
## Summary

Updated package dependencies across projects and improved formatting for existing documentation.

## Motivation

This change ensures compatibility with the latest versions of dependencies and enhances readability in the documentation.

## Type of change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would break existing API contracts)
- [x] 📚 Documentation only
- [x] ♻️ Refactor / internal cleanup (no behaviour change)
- [ ] ⚡ Performance improvement (please attach BenchmarkDotNet diff)
- [ ] 🧪 Tests only
- [ ] 🔧 CI / tooling

## Checklist

- [ ] I have read [`CONTRIBUTING.md`](../CONTRIBUTING.md).
- [ ] My commits follow the [Conventional Commits](https://www.conventionalcommits.org/) specification.
- [ ] I have added or updated tests covering my change.
- [ ] `dotnet build CaeriusNet.slnx -c Release -p:TreatWarningsAsErrors=true` succeeds locally.
- [ ] `dotnet test CaeriusNet.slnx -c Release --filter "FullyQualifiedName!~IntegrationTests"` is green.
- [ ] `pwsh ./.github/scripts/ValidatePackage.ps1 -Configuration Release -OutputDirectory .work/package-validation` succeeds for package/public API changes.
- [ ] `cd Documentations && npm install && npm run docs:build` succeeds for documentation changes (or `npm ci` when a lockfile exists).
- [ ] Docker-backed integration tests were run when storage, transactions, SQL, or TVP behaviour changed.
- [ ] I have updated [`CHANGELOG.md`](../CHANGELOG.md) under `[Unreleased]` if user-visible.
- [ ] I have updated public XML documentation comments for any public API change.
- [x] No new dependencies introduced (or discussed in an issue first).

## Public-API impact

No impact on the public-facing API.

## Benchmark / performance notes

No performance changes introduced.

## Screenshots / logs (optional)

N/A